### PR TITLE
Restart the workflow to activate steps added via installation.xml (bsc#949185)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct  7 19:22:13 UTC 2015 - lslezak@suse.cz
+
+- restart the installation workflow to activate the new
+  installation steps added by an add-on via installation.xml
+  (bsc#949185)
+- 3.1.11
+
+-------------------------------------------------------------------
 Thu Dec  4 09:49:06 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_add-on.rb
+++ b/src/clients/inst_add-on.rb
@@ -85,6 +85,14 @@ module Yast
         true
       )
 
+      if @ret == :next
+        @ret = ProductControl.RunFrom(
+          Ops.add(ProductControl.CurrentStep, 1),
+          true
+        )
+        @ret = :finish if @ret == :next
+      end
+
       @ret 
 
       # EOF

--- a/src/clients/inst_add-on.rb
+++ b/src/clients/inst_add-on.rb
@@ -5,13 +5,11 @@
 # Summary:	Select add-on products for installation
 # Authors:	Jiri Srain <jsrain@suse.de>
 #
-
-# NOTE: this client should not be called from other clients directly
-# via WFM.call (only from the control.xml file), it can restart the workflow
-# from the next step and return to the caller AFTER the complete workflow
-# is finished (or aborted)
-
 module Yast
+  # @note This client should not be called from other clients directly
+  #  via WFM.call (only from the control.xml file), it can restart the workflow
+  #  from the next step and return to the caller AFTER the complete workflow
+  #  is finished (or aborted)
   class InstAddOnClient < Client
     def main
       Yast.import "UI"

--- a/src/clients/inst_add-on.rb
+++ b/src/clients/inst_add-on.rb
@@ -5,6 +5,12 @@
 # Summary:	Select add-on products for installation
 # Authors:	Jiri Srain <jsrain@suse.de>
 #
+
+# NOTE: this client should not be called from other clients directly
+# via WFM.call (only from the control.xml file), it can restart the workflow
+# from the next step and return to the caller AFTER the complete workflow
+# is finished (or aborted)
+
 module Yast
   class InstAddOnClient < Client
     def main
@@ -86,6 +92,9 @@ module Yast
       )
 
       if @ret == :next
+        # be careful when calling this client from other modules, this will
+        # start the workflow from the next step and THEN return back
+        # to the caller
         @ret = ProductControl.RunFrom(
           Ops.add(ProductControl.CurrentStep, 1),
           true


### PR DESCRIPTION
The registration module directly called the add-on module, that made some troubles as some parts of the registration module were skipped when add-on restarted the workflow from the next step.

That add-on call has been removed from the registration module, now it is called from the `control.xml` file so we can revert the patch and restart the workflow again. The restart is needed to activate the newly added steps from `installation.xml`.

@jsuchome has tested the patch with Cloud6 addon (https://bugzilla.suse.com/show_bug.cgi?id=949185#c9), I have tested the patch with some addons from SCC (just to make sure it still works properly).