### PR TITLE
Added missing "priority" tag in the AutoYaST schema (bsc#976457)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 22 11:49:43 UTC 2016 - lslezak@suse.cz
+
+- Added missing "priority" tag in the AutoYaST schema (bsc#976457)
+- 3.1.13
+
+-------------------------------------------------------------------
 Thu Feb 11 15:15:24 CET 2016 - schubi@suse.de
 
 - Confirming add-on product licenses while AutoYaST installation.

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        3.1.12
+Version:        3.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/add-on.rnc
+++ b/src/autoyast-rnc/add-on.rnc
@@ -12,6 +12,7 @@ listentry =
      alias? &
      product_dir? &
      ask_on_error? &
+     priority? &
      element signature-handling {
         element accept_unsigned_file { BOOLEAN }? &
         element accept_file_without_checksum { BOOLEAN }? &
@@ -45,6 +46,7 @@ name = element name { text }
 alias = element alias { text }
 product_dir = element product_dir { text }
 ask_on_error = element ask_on_error { BOOLEAN }
+priority = element priority { INTEGER }
 add_on_products =
   element add_on_products {
      attribute config:type { text }?,


### PR DESCRIPTION
Fix for https://bugzilla.suse.com/show_bug.cgi?id=976457, the profile does not validate because of the `priority` value in the profile:

```xml
<priority config:type="integer">50</priority>
```

The `priority` key is handled in the [`Import` method](https://github.com/yast/yast-packager/blob/master/src/modules/AddOnProduct.rb#L1919), but not described in the profile schema.

- 3.1.13