### PR TITLE
Do not reset add-on signature handling by the general sign. handling

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 27 16:52:55 CEST 2016 - schubi@suse.de
+
+- AutoYaST: Do not reset add-on signature handling by the general
+  signature handling. (bnc#976859)
+- 3.1.14
+
+-------------------------------------------------------------------
 Fri Apr 22 11:49:43 UTC 2016 - lslezak@suse.cz
 
 - Added missing "priority" tag in the AutoYaST schema (bsc#976457)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        3.1.13
+Version:        3.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/add-on_auto.rb
+++ b/src/clients/add-on_auto.rb
@@ -207,8 +207,6 @@ module Yast
             # bugzilla #260613
             AddOnProduct.Integrate(srcid) if srcid != -1
 
-            # reset to global sig-handling
-            AutoinstGeneral.SetSignatureHandling
           end while Ops.get(@sources, [media, pth], -1) == -1 &&
             Ops.get_boolean(prod, "ask_on_error", false) == true
           Ops.set(prod, "media", Ops.get(@sources, [media, pth], -1))


### PR DESCRIPTION
I have implemented it like it is described in the official documentation:
https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#Software.Selections.additional

So, add-on signature handling will "win" before the general signature handling.