### PR TITLE
 	Fix layout of Add-On screen (bsc#951720)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 14 14:20:17 UTC 2016 - cwh@suse.com
+
+- Fix layout of Add-On screen (bsc#951720)
+- 3.1.16
+
+-------------------------------------------------------------------
 Tue May 31 07:43:57 UTC 2016 - igonzalezsosa@suse.com
 
 - Drop yast2-add-on-devel-doc package (fate#320356).

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        3.1.15
+Version:        3.1.16
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1156,7 +1156,7 @@ module Yast
           # bugzilla #305788
           # Use new wizard window for adding new Add-On.
           # Do not use "Steps" dialog.
-          Wizard.OpenNextBackDialog
+          Wizard.OpenLeftTitleNextBackDialog
           Wizard.SetTitleIcon("yast-addon")
           ret2 = RunWizard()
           Wizard.CloseDialog


### PR DESCRIPTION
This goes along with some changes in yast-package in a separate PR (https://github.com/yast/yast-packager/pull/172)
Compare the screenshots to see the matching layout.
Please note that this PR only affects the general dialog layout (Title on the left) - the order of the labels and checkboxes is changed in yast-package.

![greeter](https://cloud.githubusercontent.com/assets/336868/16842891/551d6652-49df-11e6-8dc0-2a1cdc774595.png)
![addondialog-license_new](https://cloud.githubusercontent.com/assets/336868/16842898/5f90d4c0-49df-11e6-989f-03b2f09f7913.png)
