### PR TITLE
Docker sle12 sp2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.yardoc
+doc/autodocs
 Makefile
 /Makefile.am
 Makefile.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
 
 before_install:
   - docker build -t yast-add-on-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it yast-add-on-image rpm -qa | sort
+
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
-language: cpp
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "ruby2.1 rake yast2-devtools" -g "yast-rake yard gettext"
-script:
-    - rake check:syntax
-    - rake check:pot
-    - yardoc
-    - rake test:unit
-    - sudo rake install
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-add-on-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-add-on-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby:sle12-sp2
+COPY . /usr/src/app
+


### PR DESCRIPTION
- This is basically a copy from `master`
- Only `yastdevel/ruby:sle12-sp2` is used instead of `yastdevel/ruby`
- Testsuite and .gitignore updated