### PR TITLE
Display also the repository path in the URL column (fate#323886)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 20 16:46:37 UTC 2017 - lslezak@suse.cz
+
+- Display also the repository path in the URL column if it is
+  defined (fate#323886)
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Aug 16 08:59:30 UTC 2017 - ancor@suse.com
 
 - Removed support for floppy (fate#319096)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        3.3.1
+Version:        4.0.0
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0


### PR DESCRIPTION
If the repository comes from a multi module medium then the repository subdirectory should be displayed as well.

That's important esp. if you add several repositories, the same URL is confusing.

![addon_path](https://user-images.githubusercontent.com/907998/30656648-177ebc78-9e35-11e7-809f-1e78b8b612ec.png)
