### PR TITLE
Allow pre-setting the defaults for the new addon URL (FATE#323163)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct 19 11:14:52 UTC 2017 - lslezak@suse.cz
+
+- Allow preselecting the add-on URL schema and hiding the "I would
+  like to install an additional Add On Product" check box from
+  the external code (FATE#323163)
+- 4.0.1
+
+-------------------------------------------------------------------
 Wed Sep 20 16:46:37 UTC 2017 - lslezak@suse.cz
 
 - Display also the repository path in the URL column if it is

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1146,9 +1146,9 @@ module Yast
 
           # adding new add-on
         elsif ret == :add || ret == :skip_to_add
-          # show checkbox only first time in installation when there is no
-          # other addons, so allow to quickly skip adding addons, otherwise
-          # it make no sense as user explicitelly want add addon.
+          # Show the checkbox only the first time in installation when there is no
+          # other addon present, allow to quickly skip adding addons. In the
+          # following runs it makes no sense as user explicitly wants to add an addon.
           # Change the state only if it has the default value (nil),
           # if the check box state has been already set then keep it unchanged.
           if SourceDialogs.display_addon_checkbox.nil?

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -174,7 +174,10 @@ module Yast
     def MediaSelect
       aliases = {
         "type"  => lambda do
-          ret = TypeDialog()
+          # use the preselected type or the same type as for the previous add-on,
+          # if not set it will use the default (the code actually runs
+          # SourceDialogs.SetURL(SourceDialogs.GetURL) internally)
+          ret = TypeDialogOpts(true, SourceDialogs.GetURL)
           log.debug "SourceDialogs.addon_enabled: #{SourceDialogs.addon_enabled}"
           # explicitly check for false (nil means the checkbox was not displayed)
           ret = :skip if ret == :next && SourceDialogs.addon_enabled == false
@@ -1145,8 +1148,12 @@ module Yast
         elsif ret == :add || ret == :skip_to_add
           # show checkbox only first time in installation when there is no
           # other addons, so allow to quickly skip adding addons, otherwise
-          # it make no sense as user explicitelly want add addon
-          SourceDialogs.display_addon_checkbox = ret == :skip_to_add
+          # it make no sense as user explicitelly want add addon.
+          # Change the state only if it has the default value (nil),
+          # if the check box state has been already set then keep it unchanged.
+          if SourceDialogs.display_addon_checkbox.nil?
+            SourceDialogs.display_addon_checkbox = (ret == :skip_to_add)
+          end
 
           # bugzilla #293428
           # Release all sources before adding a new one


### PR DESCRIPTION
- Allow preselecting the add-on URL schema and hiding the *"I would like to install an additional Add On Product"* check box from the external code.
- Related to [FATE#323163](https://fate.suse.com/323163)
- 4.0.1