### PR TITLE
Fixed checkbox behavior (bsc#1065843)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 31 12:41:46 UTC 2017 - lslezak@suse.cz
+
+- Hide the "I would like to install an additional Add On Product"
+  check box after pressing "Add" button (fix up for the previous
+  change) (bsc#1065843)
+- 4.0.2
+
+-------------------------------------------------------------------
 Thu Oct 19 11:14:52 UTC 2017 - lslezak@suse.cz
 
 - Allow preselecting the add-on URL schema and hiding the "I would

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1151,8 +1151,11 @@ module Yast
           # following runs it makes no sense as user explicitly wants to add an addon.
           # Change the state only if it has the default value (nil),
           # if the check box state has been already set then keep it unchanged.
-          if SourceDialogs.display_addon_checkbox.nil?
-            SourceDialogs.display_addon_checkbox = (ret == :skip_to_add)
+          if SourceDialogs.display_addon_checkbox.nil? && ret == :skip_to_add
+            SourceDialogs.display_addon_checkbox = true
+          # never display the checkbox after pressing [Add]
+          elsif SourceDialogs.display_addon_checkbox && ret == :add
+            SourceDialogs.display_addon_checkbox = false
           end
 
           # bugzilla #293428


### PR DESCRIPTION
- Fixes [openQA regression](https://openqa.suse.de/tests/1240331#step/addon_products_sle/8) caused by the previous fix
- After pressing the *Add* button the checkbox should not be displayed
