### PR TITLE
Fixed using a multi repository medium (bsc#1062813)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage
 /doc/autodocs
 .yardoc
 *.pot

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Travis Build](https://travis-ci.org/yast/yast-add-on.svg?branch=master)](https://travis-ci.org/yast/yast-add-on)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-add-on-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-add-on-master/)
-
+[![Coverage Status](https://coveralls.io/repos/github/yast/yast-add-on/badge.svg?branch=master)](https://coveralls.io/github/yast/yast-add-on?branch=master)

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  4 13:16:40 UTC 2017 - lslezak@suse.cz
+
+- Fixed adding multiple products from a multi-product medium
+  (bsc#1062813)
+- 4.0.3
+
+-------------------------------------------------------------------
 Tue Oct 31 12:41:46 UTC 2017 - lslezak@suse.cz
 
 - Hide the "I would like to install an additional Add On Product"

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,17 +17,19 @@
 
 
 Name:           yast2-add-on
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0
 Group:          System/YaST
 Url:            http://github.com/yast/yast-add-on
 Source0:        %{name}-%{version}.tar.bz2
-BuildRequires:  rubygem(yast-rake)
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2 >= 3.0.1
 BuildRequires:  yast2-devtools >= 3.1.10
+BuildRequires:  yast2-packager
 Requires:       autoyast2-installation
 # ProductProfile
 Requires:       yast2 >= 3.0.1

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -54,6 +54,11 @@ module Yast
       @new_addon_name = ""
 
       @product_infos = {}
+
+      # track the added repositories, using AddOnProduct.src_id does not work
+      # for multiple repository medium
+      # Arry<Fixnum>
+      @added_repos = []
     end
 
     # Initialize current inst. sources
@@ -129,44 +134,32 @@ module Yast
     # used Add-Ons are stored in AddOnProduct::add_on_products
     # bnc #393620
     def AddAddOnToStore(src_id)
-      if src_id == nil
-        Builtins.y2error("Wrong src_id: %1", src_id)
+      if src_id.nil?
+        log.error("Wrong src_id: #{src_id}")
         return
       end
 
       # BNC #450274
       # Prevent from adding one product twice
-      matching_products = Builtins.filter(AddOnProduct.add_on_products) do |one_product|
-        Ops.get_integer(one_product, "media", -1) == src_id
+      matching_product = AddOnProduct.add_on_products.find do |one_product|
+        one_product["media"] == src_id
       end
 
-      if Ops.greater_than(Builtins.size(matching_products), 0)
-        Builtins.y2milestone("Product already added: %1", matching_products)
+      if matching_product
+        log.info("Product already added: #{matching_product}")
         return
       end
 
       source_data = Pkg.SourceGeneralData(src_id)
 
-      AddOnProduct.add_on_products = Builtins.add(
-        AddOnProduct.add_on_products,
+      AddOnProduct.add_on_products <<
         {
-          "media"       => AddOnProduct.src_id,
+          "media"       => src_id,
           # table cell
-          "product"     => Ops.get_locale(
-            source_data,
-            "name",
-            Ops.get_locale(
-              source_data,
-              "alias",
-              _("No product found in the repository.")
-            )
-          ),
-          "media_url"   => Ops.get_string(source_data, "url", ""),
-          "product_dir" => Ops.get_string(source_data, "product_dir", "")
+          "product"     => source_data["name"],
+          "media_url"   => source_data["url"],
+          "product_dir" => source_data["product_dir"]
         }
-      )
-
-      nil
     end
 
     # Run dialog for selecting the media
@@ -224,37 +217,31 @@ module Yast
         sources_after = Pkg.SourceGetCurrent(false)
         Builtins.y2milestone("Sources with new one added: %1", sources_after)
 
-        # bnc #393011
-        # AddOnProduct::src_id must be set to the latest source ID
-        src_id_found = false
+        @added_repos = []
 
-        Builtins.foreach(sources_after) do |one_source|
-          if !Builtins.contains(sources_before, one_source)
-            AddOnProduct.src_id = one_source
-            Builtins.y2milestone("Added source ID is: %1", AddOnProduct.src_id)
-            src_id_found = true
-            raise Break
-          end
+        sources_after.each do |source|
+          next if sources_before.include?(source)
+
+          @added_repos << source
+          log.info("Added source ID: #{source}")
         end
 
-        if src_id_found
-          # BNC #481828: Using LABEL from content file as a repository name
-          Packages.AdjustSourcePropertiesAccordingToProduct(AddOnProduct.src_id)
-          # used add-ons are stored in a special list
-          AddAddOnToStore(AddOnProduct.src_id)
+        if !@added_repos.empty?
+          @added_repos.each do |src_id|
+            # BNC #481828: Using LABEL from content file as a repository name
+            Packages.AdjustSourcePropertiesAccordingToProduct(src_id)
+            # used add-ons are stored in a special list
+            AddAddOnToStore(src_id)
+          end
         else
-          AddOnProduct.src_id = Ops.get(
-            sources_after,
-            Ops.subtract(Builtins.size(sources_after), 1),
-            0
-          )
-          Builtins.y2warning("Fallback src_id: %1", AddOnProduct.src_id)
+          @added_repos << sources_after.last
+          log.warn("Fallback src_id: #{sources_after.last}")
         end
 
         # BNC #441380
-        # Refresh and load the added source, this is needed since the unified
+        # Refresh and load the added sources, this is needed since the unified
         # functions from packager are used.
-        Pkg.SourceRefreshNow(AddOnProduct.src_id)
+        @added_repos.each { |src_id| Pkg.SourceRefreshNow(src_id) }
         Pkg.SourceLoad
 
         # BNC #468449
@@ -458,49 +445,23 @@ module Yast
     # BNC #474745
     # Installs all the products from just added add-on media
     def InstallProduct
-      Builtins.y2milestone("AddOnID: %1", AddOnProduct.src_id)
+      log.info("Installing products from #{@added_repos.inspect}")
 
-      if AddOnProduct.src_id == nil || Ops.less_than(AddOnProduct.src_id, 0)
-        Builtins.y2error("No source has been added")
+      if @added_repos.empty?
+        log.error("No source has been added")
         return :next
       end
 
       all_products = Pkg.ResolvableProperties("", :product, "")
-
-      # `selected and `installed products
-      # each map contains "name" and "version"
-      s_a_i_products = []
-
-      Builtins.foreach(all_products) do |one_product|
-        s_a_i_products = Builtins.add(
-          s_a_i_products,
-          {
-            "name"    => Ops.get_string(one_product, "name", "xyz"),
-            "version" => Ops.get_string(one_product, "version", "abc")
-          }
-        )
-      end
-
-      Builtins.foreach(all_products) do |one_product|
-        #	map this_product = $["name":one_product["name"]:"zyx", "version":one_product["version"]:"cba"];
-
+      all_products.each do |product|
         # Product doesn't match the new source ID
-        if Ops.get_integer(one_product, "source", -255) != AddOnProduct.src_id
-          next
-        end
+        next unless @added_repos.include?(product["source"])
         # Product is not available (either `installed or `selected or ...)
-        next if Ops.get_symbol(one_product, "status", :available) != :available
-        #	// Available but also already installed or selected
-        #	if (contains (s_a_i_products, this_product)) {
-        #	    y2warning ("Product %1 is already installed", this_product);
-        #	    return;
-        #	}
-        product_name = Ops.get_string(one_product, "name", "-Unknown-Product-")
-        Builtins.y2milestone(
-          "Selecting product '%1' for installation -> %2",
-          product_name,
-          Pkg.ResolvableInstall(product_name, :product)
-        )
+        next if product["status"] != :available
+
+        success = Pkg.ResolvableInstall(product["name"], :product)
+
+        log.info("Selecting product '#{product["name"]}' for installation -> #{success}")
       end
 
       :next
@@ -843,11 +804,8 @@ module Yast
 
     # Check new product compliance; may abort the installation
     def CheckCompliance
-      if ProductProfile.CheckCompliance(AddOnProduct.src_id)
-        return :next
-      else
-        return :abort
-      end
+      compliant = @added_repos.all?{ |src_id| ProductProfile.CheckCompliance(src_id) }
+      compliant ? :next : :abort
     end
 
     def RunWizard
@@ -857,7 +815,6 @@ module Yast
         "check_compliance" => lambda { CheckCompliance() }
       }
 
-
       sequence = {
         "ws_start"        => "media",
         "media"           => {
@@ -866,16 +823,6 @@ module Yast
           :finish => "check_compliance",
           :skip   => :skip
         },
-        #	"catalog" : $[
-        #	    `abort : `abort,
-        #	    `next : "product",
-        #	    `finish : `next,
-        #	],
-        #	"product" : $[
-        #	    `abort : `abort,
-        #	    `next : `next,
-        #	    `finish : `next,
-        #	],
         "check_compliance" => {
           :abort => :abort,
           :next  => "install_product"
@@ -890,9 +837,10 @@ module Yast
     end
 
     def RunAutorunWizard
-      aliases = { "catalog" => lambda { CatalogSelect() }, "product" => lambda do
-        ProductSelect()
-      end }
+      aliases = {
+        "catalog" => lambda { CatalogSelect() },
+        "product" => lambda { ProductSelect() }
+      }
 
       sequence = {
         "ws_start" => "catalog",
@@ -901,8 +849,6 @@ module Yast
       }
       Sequencer.Run(aliases, sequence)
     end
-
-
 
     def Redraw(enable_back, enable_next, enable_abort, back_button, next_button, abort_button)
       Builtins.y2milestone("Called Redraw()")
@@ -1175,32 +1121,29 @@ module Yast
 
           if ret2 == :next
             # Add-On product has been added, integrate it (change workflow, use y2update)
-            AddOnProduct.Integrate(AddOnProduct.src_id)
+            @added_repos.each { |src_id| AddOnProduct.Integrate(src_id) }
 
             # check whether it requests registration (FATE #301312)
-            AddOnProduct.PrepareForRegistration(AddOnProduct.src_id)
+            @added_repos.each { |src_id| AddOnProduct.PrepareForRegistration(src_id) }
             some_addon_changed = true
             # do not keep first_time, otherwise summary won't be shown during installation
             ret = nil if ret == :skip_to_add
           elsif ret2 == :abort || ret2 == :cancel
             Builtins.y2milestone("Add-on sequence aborted")
 
-            if AddOnProduct.src_id != nil
-              Builtins.y2milestone(
-                "Removing add-on repository: %1",
-                AddOnProduct.src_id
-              )
+            if !@added_repos.empty?
+              log.info("Removing add-on repositories: #{@added_repos.inspect}")
 
               # remove the repository
-              Pkg.SourceDelete(AddOnProduct.src_id)
+              @added_repos.each do |src_id|
+                Pkg.SourceDelete(src_id)
 
-              AddOnProduct.add_on_products = Builtins.filter(
-                AddOnProduct.add_on_products
-              ) do |add_on_product|
-                Ops.get_integer(add_on_product, "media", -1) !=
-                  AddOnProduct.src_id
+                AddOnProduct.add_on_products.reject! do |add_on_product|
+                    add_on_product["media"] == src_id
+                end
               end
             end
+
             # properly return abort in installation
             ret = :abort if ret == :skip_to_add
           # extra handling for the global enable checkbox

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -1,0 +1,108 @@
+require_relative "./test_helper"
+
+Yast.import "Pkg"
+Yast.import "Sequencer"
+Yast.import "Packages"
+
+# just a wrapper class for the repositories_include.rb
+module Yast
+  class AddOnWorkflowIncludeTesterClass < Module
+    extend Yast::I18n
+
+    def main
+      Yast.include self, "add-on/add-on-workflow.rb"
+    end
+  end
+end
+
+AddonIncludeTester = Yast::AddOnWorkflowIncludeTesterClass.new
+AddonIncludeTester.main
+
+describe "Yast::AddOnWorkflowInclude" do
+  subject { AddonIncludeTester }
+
+  describe "#MediaSelect" do
+    before do
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([])
+      allow(Yast::Sequencer).to receive(:Run).and_return(:next)
+      allow(Yast::Packages).to receive(:AdjustSourcePropertiesAccordingToProduct)
+      allow(subject).to receive(:AddAddOnToStore)
+      allow(Yast::Pkg).to receive(:SourceRefreshNow)
+      allow(Yast::Pkg).to receive(:SourceLoad)
+      allow(Yast::Pkg).to receive(:SourceSaveAll)
+      allow(Yast::AddOnProduct).to receive(:last_ret=)
+    end
+
+    it "returns the UI symbol" do
+      expect(Yast::Sequencer).to receive(:Run).and_return(:next)
+      expect(subject.MediaSelect).to eq(:next)
+    end
+
+    it "refreshes all added repositories and loads the available packages" do
+      # no initial repository, then 2 repositories added
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([], [42,43])
+      expect(Yast::Pkg).to receive(:SourceRefreshNow).with(42)
+      expect(Yast::Pkg).to receive(:SourceRefreshNow).with(43)
+      expect(Yast::Pkg).to receive(:SourceLoad)
+
+      subject.MediaSelect
+    end
+  end
+
+  describe "#InstallProduct" do
+    context "no repository has been added" do
+      before do
+        AddonIncludeTester.instance_variable_set("@added_repos", [])
+      end
+
+      it "does not select any product" do
+        expect(Yast::Pkg).to_not receive(:ResolvableInstall)
+        AddonIncludeTester.InstallProduct
+      end
+
+      it "returns :next" do
+        expect(AddonIncludeTester.InstallProduct).to eq(:next)
+      end
+    end
+
+    context "some repositories have been added" do
+      # add-on products in the repositories
+      let(:p1) { { "name" => "product1", "source" => 42, "status" => :available } }
+      let(:p2) { { "name" => "product2", "source" => 43, "status" => :available } }
+
+      before do
+        AddonIncludeTester.instance_variable_set("@added_repos", [42, 43])
+      end
+
+      it "returns :next" do
+        allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([])
+        allow(Yast::Pkg).to receive(:ResolvableInstall)
+        expect(AddonIncludeTester.InstallProduct).to eq(:next)
+      end
+
+      it "selects the available products from the added repositories" do
+        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return([p1, p2])
+        expect(Yast::Pkg).to receive(:ResolvableInstall).with("product1", :product)
+        expect(Yast::Pkg).to receive(:ResolvableInstall).with("product2", :product)
+
+        AddonIncludeTester.InstallProduct
+      end
+
+      it "ignores the products from other repositories" do
+        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(
+          [p1.merge("source" => 1), p2.merge("source" => 2)])
+        expect(Yast::Pkg).to_not receive(:ResolvableInstall)
+
+        AddonIncludeTester.InstallProduct
+      end
+
+      it "ignores the already selected repositories" do
+        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(
+          [p1.merge("status" => :selected), p2.merge("status" => :selected)])
+        expect(Yast::Pkg).to_not receive(:ResolvableInstall)
+
+        AddonIncludeTester.InstallProduct
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,28 @@
+srcdir = File.expand_path("../../src", __FILE__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+
+# force English locale to avoid failing tests due to translations
+# when running in non-English environment
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+require "yast"
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # track all ruby files under src
+  SimpleCov.track_files("#{srcdir}/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatters = [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end


### PR DESCRIPTION
- All new added repositories are now processed, not only one of them
- See https://bugzilla.suse.com/show_bug.cgi?id=1062813
- Added initial unit test support
- Added some simple unit tests
- Enabled Coveralls (code coverage)
- Also tested manually in a full installation (see the screenshots below)
- Some additional cleanup

## Screenshots

If user selected several addons from a multi repository medium in this dialog:

![multi_product_selection](https://user-images.githubusercontent.com/907998/33559798-3e2d3cdc-d90e-11e7-8983-1b9f580684fe.png)

Then the addon summary listed only one of them:

![multi_product_list_broken](https://user-images.githubusercontent.com/907998/33559847-608846d2-d90e-11e7-8bd5-e9f1634fa846.png)

And only that product was selected to install:

![multi_product_summary_broken](https://user-images.githubusercontent.com/907998/33559887-809c7010-d90e-11e7-9e59-9ca4d3073619.png)

## With the Fix

After applying the fix all addons are displayed in the table:

![multi_product_list](https://user-images.githubusercontent.com/907998/33559944-a76b0094-d90e-11e7-9239-7e94dd5be197.png)

And all products are selected to install:

![multi_product_summary](https://user-images.githubusercontent.com/907998/33559966-b909ecc0-d90e-11e7-901a-9c4304113b81.png)
