### PR TITLE
Fixed a crash when when adding an addon (bsc#1074766)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  8 10:57:47 UTC 2018 - lslezak@suse.cz
+
+- Fixed a crash when when adding an addon (bsc#1074766)
+- 4.0.5
+
+-------------------------------------------------------------------
 Wed Dec 20 16:08:43 CET 2017 - schubi@suse.de
 
 - Improved error message for adding a product. (bnc#1071173)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0
@@ -35,8 +35,8 @@ Requires:       autoyast2-installation
 Requires:       yast2 >= 3.0.1
 Requires:       yast2-country
 Requires:       yast2-installation
-# SourceDialogs.display_addon_checkbox
-Requires:       yast2-packager >= 3.1.14
+# new AddOnProduct.DoInstall argument
+Requires:       yast2-packager >= 4.0.25
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Obsoletes:      yast2-add-on-devel-doc

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1765,7 +1765,7 @@ module Yast
         AddOnProduct.src_id = repo
         # just handle each repository separately, select the packages but do not
         # install them yet
-        AddOnProduct.DoInstall(false)
+        AddOnProduct.DoInstall(install_packages: false)
       end
 
       # install all packages at once

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1751,7 +1751,32 @@ module Yast
 
     def RunAddProductWorkflow
       WFM.CallFunction("inst_addon_update_sources", [])
-      AddOnProduct.DoInstall
+
+      # partition the addons into two groups:
+      # - plain addons (no installation.xml)
+      # - addons with installation.xml
+      # handle each group separately
+      plain_addons, workflow_addons = @added_repos.partition do |repo|
+        WorkflowManager.GetCachedWorkflowFilename(:addon, repo, "").nil?
+      end
+
+      plain_addons.each do |repo|
+        # the src_id value must be set before calling DoInstall
+        AddOnProduct.src_id = repo
+        # just handle each repository separately, select the packages but do not
+        # install them yet
+        AddOnProduct.DoInstall(false)
+      end
+
+      # install all packages at once
+      AddOnProduct.DoInstall_NoControlFile unless plain_addons.empty?
+
+      workflow_addons.each do |repo|
+        AddOnProduct.src_id = repo
+        # run the installation.xml
+        AddOnProduct.DoInstall
+      end
+
       # Write only when there are some changes
       Write()
 

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -116,7 +116,7 @@ describe "Yast::AddOnWorkflowInclude" do
 
     it "installs the selected products at once" do
       expect(Yast::WorkflowManager).to receive(:GetCachedWorkflowFilename).and_return(nil).twice
-      expect(Yast::AddOnProduct).to receive(:DoInstall).with(false).twice
+      expect(Yast::AddOnProduct).to receive(:DoInstall).with(install_packages: false).twice
       expect(Yast::AddOnProduct).to receive(:DoInstall_NoControlFile)
       AddonIncludeTester.RunAddProductWorkflow
     end

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -105,4 +105,27 @@ describe "Yast::AddOnWorkflowInclude" do
       end
     end
   end
+
+  describe "#RunAddProductWorkflow" do
+    before do
+      allow(Yast::WFM).to receive(:CallFunction).with("inst_addon_update_sources", [])
+      allow(Yast::Pkg).to receive(:SourceReleaseAll)
+      allow(AddonIncludeTester).to receive(:Write)
+      AddonIncludeTester.instance_variable_set("@added_repos", [1, 2])
+    end
+
+    it "installs the selected products at once" do
+      expect(Yast::WorkflowManager).to receive(:GetCachedWorkflowFilename).and_return(nil).twice
+      expect(Yast::AddOnProduct).to receive(:DoInstall).with(false).twice
+      expect(Yast::AddOnProduct).to receive(:DoInstall_NoControlFile)
+      AddonIncludeTester.RunAddProductWorkflow
+    end
+
+    it "handles addons with installation.xml" do
+      expect(Yast::WorkflowManager).to receive(:GetCachedWorkflowFilename).and_return("foo").twice
+      expect(Yast::AddOnProduct).to receive(:DoInstall).twice
+      expect(Yast::AddOnProduct).to_not receive(:DoInstall_NoControlFile)
+      AddonIncludeTester.RunAddProductWorkflow
+    end
+  end
 end


### PR DESCRIPTION
- The `AddOnProduct.src_id` value must be set before calling `AddOnProduct.DoInstall`
- The `AddOnProduct.DoInstall` must be called for each addon separately (so it can correctly integrate the optional `installation.xml` file for each addon)
- 4.0.5