### PR TITLE
Mock missing dependency necessary to run tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ end
 
 # Stub classes from other modules to speed up a build
 stub_module("AutoinstGeneral")
+stub_module("AutoinstSoftware")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
Forgotten in PR #52.

After running `rake osc:build` it seems that now both, Travis and Jenkins, will be happy :)