### PR TITLE
Refactor add on auto client

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 23 08:42:56 UTC 2018 - dgonzalez@suse.com
+
+- Refactor AddOn auto client (bsc#1081509)
+- 4.1.2
+
+-------------------------------------------------------------------
 Thu Jun 28 09:12:22 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -36,16 +36,45 @@ module Yast
       AddOnProduct.Import("add_on_products" => valid_add_on_products)
     end
 
+    # Returns an unordered HTML list summarizing the Add-on products
+    #
+    # Each item will contain information about
+    #
+    #   * URL, the "media_url" property
+    #   * Path, the "product_dir" property which will be omitted wether is not present or is the default
+    #           path ("/")
+    #   * Product, the "product" property, unless it is not present
+    #
+    # @example
+    #   <ul>
+    #     <li>URL: dvd:///</li>
+    #     <li>URL: http://product.url, Product: Product name</li>
+    #   </ul>
+    #
+    # @return [String] an unordered HTML list
     def summary
-      formatted_add_on = AddOnProduct.add_on_products.map do |add_on|
-        "<li>" \
-          "Media: #{add_on["media_url"]}, " \
-          "Path: #{add_on["product_dir"]}, " \
-          "Product: #{add_on["product"]}" \
-        "</li>"
+      formatted_add_ons = AddOnProduct.add_on_products.map do |add_on|
+        product = add_on["product"]
+        product_dir = add_on["product_dir"]
+
+        add_on_summary = []
+        # TRANSLATORS: %s is an add-on URL
+        add_on_summary << _("URL: %s") % CGI.escapeHTML(add_on["media_url"])
+
+        if [nil, "", "/"].none?(product_dir)
+          # TRANSLATORS: %s is a product path
+          add_on_summary << _("Path: %s") % CGI.escapeHTML(product_dir)
+        end
+
+        if !(product.nil? || product.empty?)
+          # TRANSLATORS: %s is the product
+          add_on_summary << _("Product: %s") % CGI.escapeHTML(product)
+        end
+
+        "<li>#{add_on_summary.join(", ")}</li>"
       end
 
-      ["<ul>", formatted_add_on, "</ul>"].join("\n")
+      ["<ul>", formatted_add_ons, "</ul>"].join("\n")
     end
 
     def modified?

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -1,328 +1,333 @@
-# encoding: utf-8
+require "yast"
+require "installation/auto_client"
 
-# File:
-#      add-on_auto.ycp
-#
-# Module:
-#      Add-On autoinstallation and configuration
-#
-# Summary:
-#      Add-On autoinstallation preparation
-#
-# Authors:
-#      Jiri Srain <jsrain@suse.cz>
-#
-# $Id$
-#
+Yast.import "AutoInstall"
+Yast.import "AddOnProduct"
+Yast.import "Progress"
+
 module Yast
-  class AddOnAutoClient < Client
-    def main
-      Yast.import "Pkg"
-      Yast.import "UI"
+  class AddOnAutoClient < ::Installation::AutoClient
+    def run
       textdomain "add-on"
-
-      Builtins.y2milestone("----------------------------------------")
-      Builtins.y2milestone("add-on auto started")
-
-      Yast.import "AddOnProduct"
-      Yast.import "Progress"
-      Yast.import "AutoinstSoftware"
-      Yast.import "PackageCallbacks"
-      Yast.import "Label"
-      Yast.import "AutoinstGeneral"
-      Yast.import "PackageLock"
-      Yast.import "Installation"
-      Yast.import "String"
 
       Yast.include self, "add-on/add-on-workflow.rb"
 
-      @progress_orig = Progress.set(false)
+      progress_orig = Yast::Progress.set(false)
+      ret = super
+      Yast::Progress.set(progress_orig)
 
+      ret
+    end
 
-      @ret = nil
-      @func = ""
-      @param = {}
+    def import(data)
+      add_on_products = data.fetch("add_on_products", [])
 
-      # Check arguments
-      if Ops.greater_than(Builtins.size(WFM.Args), 0) &&
-          Ops.is_string?(WFM.Args(0))
-        @func = Convert.to_string(WFM.Args(0))
-        if Ops.greater_than(Builtins.size(WFM.Args), 1) &&
-            Ops.is_map?(WFM.Args(1))
-          @param = Convert.to_map(WFM.Args(1))
+      valid_add_on_products = add_on_products.reject.with_index(1) do |add_on, index|
+        next false unless add_on.fetch("media_url", "").empty?
+
+        log.error "Missing <media_url> value in the #{index}. add-on-product definition"
+
+        # abort import/installation
+        return false unless skip_add_on_and_continue?(index)
+
+        true
+      end
+
+      AddOnProduct.Import("add_on_products" => valid_add_on_products)
+    end
+
+    def summary
+      formatted_add_on = AddOnProduct.add_on_products.map do |add_on|
+        "<li>" \
+          "Media: #{add_on["media_url"]}, " \
+          "Path: #{add_on["product_dir"]}, " \
+          "Product: #{add_on["product"]}" \
+        "</li>"
+      end
+
+      ["<ul>", formatted_add_on, "</ul>"].join("\n")
+    end
+
+    def modified?
+      AddOnProduct.modified
+    end
+
+    def modified
+      AddOnProduct.modified = true
+    end
+
+    def reset
+      AddOnProduct.add_on_products = []
+    end
+
+    def change
+      Wizard.CreateDialog
+      AutoinstSoftware.pmInit
+      PackageCallbacks.InitPackageCallbacks
+
+      ret = RunAddOnMainDialog(
+        false,
+        true,
+        true,
+        Label.BackButton,
+        Label.OKButton,
+        Label.CancelButton,
+        false
+      )
+
+      Wizard.CloseDialog
+
+      ret
+    end
+
+    def export
+      AddOnProduct.Export
+    end
+
+    # Creates sources from add on products
+    #
+    # This method always will return `true`. However, there are two scenarios that could happen and it is
+    # worth to take in mind:
+    #
+    #   * system will be halted immediately as soon a required license will be rejected
+    #   * a source could be omitted if there is an error adding it and no retries are performed
+    #
+    # @see {create_source}
+    #
+    # @return [true]
+    def write
+      AddOnProduct.add_on_products.each do |add_on|
+        product = add_on.fetch("product", "")
+        media_url = media_url_for(add_on)
+        action = create_source(add_on, product, media_url)
+
+        case action
+        when :report_error
+          report_error_for(product, media_url)
+        when :halt_system
+          halt_system
         end
       end
-      Builtins.y2debug("func=%1", @func)
-      Builtins.y2debug("param=%1", @param)
 
-      if @func == "Import"
-        add_on_products = @param["add_on_products"] || []
-        count = 0
-        # Checking needed values
-        add_on_products.reject! do |product|
-          count += 1
-          if product["media_url"].nil? || product["media_url"] == ""
-            # Report missing media_url entry in the AutoYaST configuration file
-            # TRANSLATORS: The placeholder points to the location in the AutoYaST configuration file.
-            error_string = format(_("Error in the AutoYaST <add_on> section.\n" \
-              "Missing mandatory <media_url> value at index %d in the <add_on_products> definition.\n" \
-              "Skip the invalid product definition and continue with the installation?"),
-              count)
-            log.error "Missing <media_url> value in the #{count}. add-on-product definition"
-            return false unless Popup.ContinueCancel(error_string) # user abort
-            true
-          else
-            false
-          end
+      # reread agents, redraw wizard steps, etc.
+      AddOnProduct.ReIntegrateFromScratch
+
+      true
+    end
+
+    def read
+      if !PackageLock.Check
+        log.error("Cannot get package lock")
+
+        return false
+      end
+
+      log.info("Reseting Pkg")
+
+      Pkg.PkgApplReset
+      Pkg.PkgReset
+      Pkg.TargetInitialize(Installation.destdir)
+      Pkg.TargetLoad
+      Pkg.SourceStartManager(true)
+      Pkg.PkgSolve(true)
+
+      ReadFromSystem()
+    end
+
+  private
+
+    # Create repo and install product (if given)
+    #
+    # @param [Hash] add_on
+    # @param [String] product
+    # @param [String] media_url
+    #
+    # @return [Symbol] a symbol that represent an action
+    #   :report_error if source could not be created
+    #   :halt_system if a required license was not accepted
+    #   :continue if source was created successfully
+    def create_source(add_on, product, media_url)
+      url = expand_url_for(add_on, media_url)
+      product_dir = add_on.fetch("product_dir", "/")
+      retry_on_error = add_on.fetch("ask_on_error", false)
+
+      # Set addon specific sig-handling
+      AddOnProduct.SetSignatureCallbacks(product)
+
+      loop do
+        source_id = Pkg.SourceCreate(url, product_dir)
+
+        log.info("New source ID: #{source_id}")
+
+        if [nil, -1].include?(source_id)
+          retry_on_error &&= retry_again?(product, media_url)
+
+          return :report_error unless retry_on_error
+        elsif !accepted_license?(add_on, source_id)
+          # Lic
+          Pkg.SourceDelete(source_id)
+
+          return :halt_system
+        else
+          # bugzilla #260613
+          AddOnProduct.Integrate(source_id)
+
+          adjust_source_attributes(add_on, source_id)
+          install_product(product)
+
+          return :continue
         end
-        @ret = AddOnProduct.Import("add_on_products"=>add_on_products)
-      # Create a summary
-      # return string
-      elsif @func == "Summary"
-        @ret = "<ul>\n"
-        Builtins.foreach(AddOnProduct.add_on_products) do |prod|
-          @ret = Ops.add(
-            Convert.to_string(@ret),
-            Builtins.sformat(
-              _("<li>Media: %1, Path: %2, Product: %3</li>\n"),
-              Ops.get_string(prod, "media_url", ""),
-              Ops.get_string(prod, "product_dir", "/"),
-              Ops.get_string(prod, "product", "")
-            )
-          )
-        end
-        @ret = Ops.add(Convert.to_string(@ret), "</ul>")
-      # did configuration changed
-      # return boolean
-      elsif @func == "GetModified"
-        @ret = AddOnProduct.modified
-      # set configuration as changed
-      # return boolean
-      elsif @func == "SetModified"
-        AddOnProduct.modified = true
-        @ret = true
-      # Reset configuration
-      # return map or list
-      elsif @func == "Reset"
-        AddOnProduct.add_on_products = []
-        @ret = {}
-      # Change configuration
-      # return symbol (i.e. `finish || `accept || `next || `cancel || `abort)
-      elsif @func == "Change"
-        Wizard.CreateDialog
-        AutoinstSoftware.pmInit
-        PackageCallbacks.InitPackageCallbacks
-        @ret = RunAddOnMainDialog(
-          false,
-          true,
-          true,
-          Label.BackButton,
-          Label.OKButton,
-          Label.CancelButton,
-          false
-        )
-        UI.CloseDialog
-        return deep_copy(@ret)
-      # Return configuration data
-      # return map or list
-      elsif @func == "Export"
-        @ret = AddOnProduct.Export
-      # Write configuration data
-      # return boolean
-      #
-      #
-      # **Structure:**
-      #
-      #
-      #      <add-on>
-      #     	<add_on_products config:type="list">
-      #     		<listentry>
-      #     			<media_url>http://software.opensuse.org/download/server:/dns/SLE_10/</media_url>
-      #     			<product>buildservice</product>
-      #     			<product_dir>/</product_dir>
-      #     			<!-- (optional) -->
-      #     			<name>User-Defined Product Name</name>
-      #     			<signature-handling>
-      #     				<accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
-      #     				<accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
-      #     				<accept_verification_failed config:type="boolean">true</accept_verification_failed>
-      #     				<accept_unknown_gpg_key>
-      #     					<all config:type="boolean">true</all>
-      #     					<keys config:type="list">
-      #     						<keyid>...</keyid>
-      #     						<keyid>3B3011B76B9D6523</keyid>
-      #     					</keys>
-      #     				</accept_unknown_gpg_key>
-      #     				<accept_non_trusted_gpg_key>
-      #     				<all config:type="boolean">true</all>
-      #     					<keys config:type="list">
-      #     						<keyid>...</keyid>
-      #     					</keys>
-      #     				</accept_non_trusted_gpg_key>
-      #     				<import_gpg_key>
-      #     					<all config:type="boolean">true</all>
-      #     					<keys config:type="list">
-      #     						<keyid>...</keyid>
-      #     					</keys>
-      #     				</import_gpg_key>
-      #     			</signature-handling>
-      #     		</listentry>
-      #     	</add_on_products>
-      #      </add-on>
-      #
-      elsif @func == "Write"
-        @sources = {}
+      end
+    end
 
-        AddOnProduct.add_on_products.each do |prod|
-          media = Ops.get_string(prod, "media_url", "")
-          pth = Ops.get_string(prod, "product_dir", "/")
-          if String.StartsWith(media, "relurl://")
-            base = AddOnProduct.GetBaseProductURL
-            media = AddOnProduct.GetAbsoluteURL(base, media)
-            Builtins.y2milestone("relurl changed to %1", media)
-          end
-          Ops.set(@sources, media, Ops.get(@sources, media, {}))
-          # set addon specific sig-handling
-          AddOnProduct.SetSignatureCallbacks(
-            Ops.get_string(prod, "product", "")
-          )
-          srcid = -1
-          begin
-            url = AddOnProduct.SetRepoUrlAlias(
-              # Expanding URL in order to "translate" tags like $releasever
-              Pkg.ExpandedUrl(media),
-              Ops.get_string(prod, "alias", ""),
-              Ops.get_string(prod, "name", "")
-            )
+    # Returns absolute media url for given add on
+    #
+    # @param [Hash] add_on
+    #
+    # @return [String] absolute media url or empty string
+    def media_url_for(add_on)
+      media_url = add_on.fetch("media_url", "")
 
-            srcid = Pkg.SourceCreate(url, pth)
+      if media_url.start_with?("relurl://")
+        media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.getBaseProductURL, media_url)
 
-            if (srcid == -1 || srcid == nil)
-              # revert back to the unexpanded URL to have the original URL
-              # in the saved /etc/zypp/repos.d file
-              Pkg.SourceChangeUrl(srcid, media)
+        log.info("relurl changed to #{media_url}", media_url)
+      end
 
-              if Ops.get_boolean(prod, "ask_on_error", false)
-                prod["ask_on_error"] = Popup.ContinueCancel(
-                  Builtins.sformat(
-                    _("Make the add-on \"%1\" available via \"%2\"."),
-                    Ops.get_string(prod, "product", ""),
-                    media
-                  )
-                )
-              else
-                # just report an error
-                # TRANSLATORS: The placeholders are for the product name and the URL.
-                error_string = format(_("Failed to add product \"%s\" via\n%s."),
-                  # TRANSLATORS: a fallback string for undefined product name
-                  prod["product"] || _("<not_defined_name>"), media)
-                Report.Error(error_string)
-              end
-            elsif Ops.get_boolean(prod, "confirm_license", false)
-              accepted = AddOnProduct.AcceptedLicenseAndInfoFile( srcid )
-              if accepted == false
-                Builtins.y2warning("License not accepted, delete the repository and halt the system")
-                Pkg.SourceDelete(srcid)
-                SCR.Execute(path(".target.bash"), "/sbin/halt -f -n -p")
-              end
-            end
+      media_url
+    end
 
-            Ops.set(@sources, [media, pth], srcid)
-            Builtins.y2milestone("New source ID: %1", srcid)
+    # Expand url for given add_on
+    #
+    # @param [Hash] add_on
+    # @param [String] media_url
+    #
+    # @return [String] expanded url
+    def expand_url_for(add_on, media_url)
+      AddOnProduct.SetRepoUrlAlias(
+        Pkg.ExpandedUrl(media_url),
+        add_on.fetch("alias", ""),
+        add_on.fetch("name", "")
+      )
+    end
 
-            # bugzilla #260613
-            AddOnProduct.Integrate(srcid) if srcid != -1
+    # Checks if should be retried to look for the source at given url
+    #
+    # @param [String] product
+    # @param [String] media_url
+    #
+    # @return [Boolean]
+    def retry_again?(product, media_url)
+      prompt = format(_("Make the add-on \"%s\" available via \"%s\"."), product, media_url)
 
-          end while Ops.get(@sources, [media, pth], -1) == -1 &&
-            Ops.get_boolean(prod, "ask_on_error", false) == true
-          Ops.set(prod, "media", Ops.get(@sources, [media, pth], -1))
-          # Adjust "name", bnc #434708
-          if srcid != nil && srcid != -1
-            repos = Pkg.SourceEditGet
+      Popup.ContinueCancel(prompt)
+    end
 
-            found_at = -1
-            counter = -1
+    # Report an error about fail adding a product
+    #
+    # @param [String] product
+    # @param [String] media_url
+    def report_error_for(product, media_url)
+      # TRANSLATORS: The placeholders are for the product name and the URL.
+      # TRANSLATORS: a fallback string for undefined product name
+      product_name = product || _("<not_defined_name>")
+      error_msg = format(_("Failed to add product \"%s\" via\n%s"), product_name, media_url)
 
-            Builtins.foreach(repos) do |one_repo|
-              counter = Ops.add(counter, 1)
-              if Ops.get_integer(one_repo, "SrcId", -1) == srcid
-                found_at = counter
-                raise Break
-              end
-            end
+      Report.Error(error_msg)
+    end
 
-            if found_at != -1
-              name = Ops.get_string(repos, [found_at, "name"], "")
+    # Tries to confirm license if needed
+    #
+    # @param [Hash] add_on
+    # @param [Integer] source_id
+    #
+    # @return [Boolean] true if is not needed to confirm license or ir accepted; false otherwise
+    def accepted_license?(add_on, source_id)
+      return true unless add_on.fetch("confirm_license", false)
 
-              # Possibility to set name in control file, bnc #433981
-              if Builtins.haskey(prod, "name")
-                name = Ops.get_string(prod, "name", "")
-                Builtins.y2milestone("Preferred name: %1", name)
-                # Or use the one returned by Pkg::RepositoryScan
-              else
-                repos_at_url = Pkg.RepositoryScan(Pkg.ExpandedUrl(media))
-                # [ ["Product Name", "Path" ] ]
-                Builtins.foreach(repos_at_url) do |one_repo|
-                  if Ops.get(one_repo, 1, "") == pth
-                    name = Ops.get(one_repo, 0, "")
-                    raise Break
-                  end
-                end
-                Builtins.y2milestone("Preferred name: %1", name)
-              end
+      AddOnProduct.AcceptedLicenseAndInfoFile(source_id)
+    end
 
-              Ops.set(repos, [found_at, "name"], name)
-              Ops.set(repos, [found_at, "priority"], prod["priority"]) if prod.key?("priority")
-              Pkg.SourceEditSet(repos)
-            end
-          end
-          if Ops.get_string(prod, "product", "") != ""
-            Builtins.y2milestone(
-              "Installing product: %1",
-              Ops.get_string(prod, "product", "")
-            )
-            Pkg.ResolvableInstall(Ops.get_string(prod, "product", ""), :product)
-          else
-            Builtins.y2warning("No product to install")
-          end
-        end
+    # Adjusts source attributes for given id
+    #
+    # At the moment to create source/repo through `Pkg.SourceCreate` is not possible to set attributes
+    # directly. In consequence, the creation must be completed making use of `Pkg.SourceEditSet`
+    #
+    # @see {https://github.com/yast/yast-pkg-bindings YaST Package Bindings}
+    #
+    # @param [Hash] add_on
+    # @param [Integer|Nil] source_id
+    def adjust_source_attributes(add_on, source_id)
+      sources = Pkg.SourceEditGet
+      index = sources.find_index { |source| source["SrcId"] == source_id }
 
-        # reread agents, redraw wizard steps, etc.
-        AddOnProduct.ReIntegrateFromScratch
+      return if index.nil?
 
-        @ret = true
-      # Reads configuration of add-ons from the current system
-      # to memory. To get that configuration, use Export() functionality.
-      #
-      # @return [Boolean]
-      elsif @func == "Read"
-        if !PackageLock.Check
-          Builtins.y2error("Cannot get package lock")
-          return false
-        end
-        Builtins.y2milestone("Reseting Pkg")
-        Pkg.PkgApplReset
-        Pkg.PkgReset
+      repo = sources[index]
+      repo["name"] = preferred_name_for(add_on, repo)
+      repo["priority"] = add_on["priority"] if add_on.key?("priority")
 
-        Pkg.TargetInitialize(Installation.destdir)
-        Pkg.TargetLoad
-        Pkg.SourceStartManager(true)
-        Pkg.PkgSolve(true)
+      log.info("Preferred name: #{repo["name"]}")
 
-        @ret = ReadFromSystem()
+      Pkg.SourceEditSet(sources)
+    end
+
+    # Returns preferred name for add-on/repo
+    #
+    # Following below precedence
+    #
+    #   * name in the add_on/control file, if given
+    #   * name of repo that matches with given media and product path, if any
+    #   * name of given repo
+    #
+    # @param [Hash] addon
+    # @param [Array] repo
+    #
+    # @return [String] preferred name for add-on/repo
+    def preferred_name_for(add_on, repo)
+      add_on_name = add_on.fetch("name", nil)
+
+      return add_on_name unless add_on_name.nil? || add_on_name.empty? # name in control file, bnc#433981
+
+      media = add_on.fetch("media")
+      product_dir = add_on.fetch("product_dir")
+      expanded_url = Pkg.ExpandedUrl(media)
+      repos_at_url = Pkg.RepositoryScan(expanded_url)
+
+      # {Pkg.RepositoryScan} output: [["Product Name", "Path"], ...]
+      found_repo = repos_at_url.find { |r| r[1] == product_dir }
+      return found_repo[0] if found_repo
+
+      repo["name"]
+    end
+
+    # Installs given product
+    #
+    # @param [String] product
+    def install_product(product)
+      if product.empty?
+        log.warn("No product to install")
       else
-        Builtins.y2error("unknown function: %1", @func)
-        @ret = false
+        log.info("Installing product: #{product}")
+        Pkg.ResolvableInstall(product, :product)
       end
-      Progress.set(@progress_orig)
+    end
 
-      Builtins.y2debug("ret=%1", @ret)
-      Builtins.y2milestone("add-on_auto finished")
-      Builtins.y2milestone("----------------------------------------")
+    def skip_add_on_and_continue?(index)
+      error_message = [
+        "Error in the AutoYaST <add_on> section.",
+        "Missing mandatory <media_url> value at index %d in the <add_on_products> definition.",
+        "Skip the invalid product definition and continue with the installation?"
+      ]
+      popup_prompt = format(_(error_message.join("\n")), index)
 
-      deep_copy(@ret)
+      Popup.ContinueCancel(popup_prompt)
+    end
 
-      # EOF
+    def halt_system
+      log.warn("License not accepted, delete the repository and halt the system")
+
+      SCR.Execute(path(".target.bash"), "/sbin/halt -f -n -p")
     end
   end
 end

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -216,7 +216,7 @@ module Yast
     def media_url_for(add_on)
       media_url = add_on.fetch("media_url", "")
 
-      if media_url.start_with?("relurl://")
+      if media_url.downcase.start_with?("relurl://")
         media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.GetBaseProductURL, media_url)
 
         log.info("relurl changed to #{media_url}")

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -246,9 +246,10 @@ module Yast
     #
     # @return [Boolean]
     def retry_again?(product, media_url)
-      prompt = format(_("Make the add-on \"%s\" available via \"%s\"."), product, media_url)
-
-      Popup.ContinueCancel(prompt)
+      Popup.ContinueCancel(
+        # TRANSLATORS: The placeholders are for the product name and the URL.
+        _("Make the add-on \"%{name}\" available via \"%{url}\".") % { name: product, url: media_url }
+      )
     end
 
     # Report an error about fail adding a product
@@ -256,10 +257,14 @@ module Yast
     # @param [String] product
     # @param [String] media_url
     def report_error_for(product, media_url)
-      # TRANSLATORS: The placeholders are for the product name and the URL.
-      # TRANSLATORS: a fallback string for undefined product name
-      product_name = product || _("<not_defined_name>")
-      error_msg = format(_("Failed to add product \"%s\" via\n%s"), product_name, media_url)
+      error_msg =
+        if product.nil? || product.empty?
+          # TRANSLATORS: The placeholder is for the URL.
+          _("Failed to add product from \n%{url}") % { url: media_url }
+        else
+          # TRANSLATORS: The placeholders are for the product name and the URL.
+          _("Failed to add product \"%{name}\" from \n%{url}") % { name: product, url: media_url }
+        end
 
       Report.Error(error_msg)
     end

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -347,14 +347,14 @@ module Yast
     end
 
     def skip_add_on_and_continue?(index)
-      error_message = [
-        "Error in the AutoYaST <add_on> section.",
-        "Missing mandatory <media_url> value at index %d in the <add_on_products> definition.",
+      # TRANSLATORS: The placeholder points to the location in the AutoYaST configuration file.
+      error_message = _(
+        "Error in the AutoYaST <add_on> section.\n" \
+        "Missing mandatory <media_url> value at index %d in the <add_on_products> definition.\n" \
         "Skip the invalid product definition and continue with the installation?"
-      ]
-      popup_prompt = format(_(error_message.join("\n")), index)
+      ) % index
 
-      Popup.ContinueCancel(popup_prompt)
+      Popup.ContinueCancel(error_message)
     end
 
     def halt_system

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -25,7 +25,7 @@ module Yast
       valid_add_on_products = add_on_products.reject.with_index(1) do |add_on, index|
         next false unless add_on.fetch("media_url", "").empty?
 
-        log.error "Missing <media_url> value in the #{index}. add-on-product definition"
+        log.error("Missing <media_url> value in the #{index}. add-on-product definition")
 
         # abort import/installation
         return false unless skip_add_on_and_continue?(index)
@@ -193,7 +193,6 @@ module Yast
 
           return :report_error unless retry_on_error
         elsif !accepted_license?(add_on, source_id)
-          # Lic
           Pkg.SourceDelete(source_id)
 
           return :halt_system
@@ -218,9 +217,9 @@ module Yast
       media_url = add_on.fetch("media_url", "")
 
       if media_url.start_with?("relurl://")
-        media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.getBaseProductURL, media_url)
+        media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.GetBaseProductURL, media_url)
 
-        log.info("relurl changed to #{media_url}", media_url)
+        log.info("relurl changed to #{media_url}")
       end
 
       media_url

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -292,11 +292,10 @@ module Yast
     # @param [Integer|Nil] source_id
     def adjust_source_attributes(add_on, source_id)
       sources = Pkg.SourceEditGet
-      index = sources.find_index { |source| source["SrcId"] == source_id }
+      repo = sources.find { |source| source["SrcId"] == source_id }
 
-      return if index.nil?
+      return if repo.nil?
 
-      repo = sources[index]
       repo["name"] = preferred_name_for(add_on, repo)
       repo["priority"] = add_on["priority"] if add_on.key?("priority")
 

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -319,7 +319,8 @@ module Yast
     def preferred_name_for(add_on, repo)
       add_on_name = add_on.fetch("name", nil)
 
-      return add_on_name unless add_on_name.nil? || add_on_name.empty? # name in control file, bnc#433981
+      # name in control file, bnc#433981
+      return add_on_name unless add_on_name.nil? || add_on_name.empty?
 
       media = add_on.fetch("media")
       product_dir = add_on.fetch("product_dir")

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -6,113 +6,40 @@ require "add-on/clients/add-on_auto"
 Yast.import "Packages"
 
 describe Yast::AddOnAutoClient do
-  describe "#run" do
-    before do
-      allow(Yast::WFM).to receive(:Args).with(no_args).and_return([func])
-      allow(Yast::WFM).to receive(:Args).with(0).and_return(func)
+  describe "#import" do
+    let(:params) do
+      { "add_on_products" => add_on_products }
     end
 
-    context "when 'func' is 'Import'" do
-      let(:func) { "Import" }
-      let(:params) do
-        { "add_on_products" => add_on_products }
-      end
+    context "when 'add_on_products' param is NOT given" do
+      it "sets 'add_on_products' to empty array" do
+        expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => [])
 
-      before do
-        allow(Yast::WFM).to receive(:Args).with(no_args).and_return([func, params])
-        allow(Yast::WFM).to receive(:Args).with(1).and_return(params)
-      end
-
-      context "and completly valid 'add_on_products' param is given" do
-        let(:add_on_products) do
-          [
-            {
-              "alias"       => "valid_add_on",
-              "media_url"   => "http://product.url",
-              "name"        => "updated_repo",
-              "priority"    => 20,
-              "product_dir" => "/"
-            }
-          ]
-        end
-
-        it "imports all add-on products given" do
-          expect(Yast::AddOnProduct).to receive(:Import).with(params)
-
-          subject.run
-        end
-      end
-
-      context "and there are missed medie_url values in given 'add_on_products'" do
-        let(:add_on_products) do
-          [
-            {
-              "alias"       => "valid_add_on",
-              "media_url"   => "http://product.url",
-              "name"        => "updated_repo",
-              "priority"    => 20,
-              "product_dir" => "/"
-            },
-            {
-              "alias"       => "not_valid_add_on",
-              "name"        => "updated_repo",
-              "priority"    => 20,
-              "product_dir" => "/"
-            }
-          ]
-        end
-        let(:valid_add_on_products) do
-          [
-            {
-              "alias"       => "valid_add_on",
-              "media_url"   => "http://product.url",
-              "name"        => "updated_repo",
-              "priority"    => 20,
-              "product_dir" => "/"
-            }
-          ]
-        end
-
-        let(:rejected_package_error) { "Missing <media_url> value in the 2. add-on-product definition" }
-        let(:missed_media_url_error) { /Missing mandatory <media_url> value at index 2/ }
-
-        it "asks to user about reject them" do
-          expect(Yast::Popup).to receive(:ContinueCancel).with(missed_media_url_error)
-
-          subject.run
-        end
-
-        it "rejects them if user decides to continue" do
-          allow(Yast::Popup).to receive(:ContinueCancel).and_return(true)
-
-          expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => valid_add_on_products)
-
-          subject.run
-        end
-
-        it "returns false (does nothing) if user decides to abort" do
-          allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
-
-          expect(Yast::AddOnProduct).to_not receive(:Import)
-
-          # expect(subject.run).to be_falsey
-        end
-      end
-
-      context "and 'add_on_products' param is NOT given" do
-        let(:params) { { something: nil } }
-
-        # it "should does nothing" do
-        it "sets 'add_on_products' to empty array" do
-          expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => [])
-
-          subject.run
-        end
+        subject.import(something: nil)
       end
     end
 
-    context "when 'func' is 'Summary'" do
-      let(:func) { "Summary" }
+    context "when completly valid 'add_on_products' param is given" do
+      let(:add_on_products) do
+        [
+          {
+            "alias"       => "valid_add_on",
+            "media_url"   => "http://product.url",
+            "name"        => "updated_repo",
+            "priority"    => 20,
+            "product_dir" => "/"
+          }
+        ]
+      end
+
+      it "imports all add-on products given" do
+        expect(Yast::AddOnProduct).to receive(:Import).with(params)
+
+        subject.import(params)
+      end
+    end
+
+    context "when there are missed medie_url values in given 'add_on_products'" do
       let(:add_on_products) do
         [
           {
@@ -124,115 +51,197 @@ describe Yast::AddOnAutoClient do
           },
           {
             "alias"       => "not_valid_add_on",
-            "media_url"   => "http://media.url",
             "name"        => "updated_repo",
             "priority"    => 20,
             "product_dir" => "/"
           }
         ]
       end
-      let(:expected_output) do
+      let(:valid_add_on_products) do
         [
-          "<ul>",
-          "<li>Media: http://product.url, Path: /, Product: </li>",
-          "<li>Media: http://media.url, Path: /, Product: </li>",
-          "</ul>"
-        ].join("\n")
+          {
+            "alias"       => "valid_add_on",
+            "media_url"   => "http://product.url",
+            "name"        => "updated_repo",
+            "priority"    => 20,
+            "product_dir" => "/"
+          }
+        ]
       end
 
-      it "returns an unordered list sumarizing current add_on_product" do
-        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
-        expect(subject.run).to eq(expected_output)
-      end
-    end
+      let(:rejected_package_error) { "Missing <media_url> value in the 2. add-on-product definition" }
+      let(:missed_media_url_error) { /Missing mandatory <media_url> value at index 2/ }
 
-    context "when 'func' is 'GetModified'" do
-      let(:func) { "GetModified" }
+      it "asks to user about reject them" do
+        expect(Yast::Popup).to receive(:ContinueCancel).with(missed_media_url_error)
 
-      context "and configuration did changed" do
-        before do
-          allow(Yast::AddOnProduct).to receive(:modified).and_return(true)
-        end
-
-        it "returns true" do
-          expect(subject.run).to be_truthy
-        end
+        subject.import(params)
       end
 
-      context "and configuration did not changed" do
-        before do
-          allow(Yast::AddOnProduct).to receive(:modified).and_return(false)
-        end
+      it "rejects them if user decides to continue" do
+        allow(Yast::Popup).to receive(:ContinueCancel).and_return(true)
 
-        it "returns true" do
-          expect(subject.run).to be_falsey
-        end
+        expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => valid_add_on_products)
+
+        subject.import(params)
+      end
+
+      it "returns false (does nothing) if user decides to abort" do
+        allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
+
+        expect(Yast::AddOnProduct).to_not receive(:Import)
       end
     end
+  end
 
-    context "when 'func' is 'SetModified'" do
-      let(:func) { "SetModified" }
-
-      it "sets configuration as changed" do
-        allow(Yast::AddOnProduct).to receive(:modified=).with(true)
-
-        subject.run
-      end
+  describe "#summary" do
+    let(:add_on_products) do
+      [
+        {
+          "alias"       => "valid_add_on",
+          "media_url"   => "http://product.url",
+          "name"        => "updated_repo",
+          "priority"    => 20,
+          "product_dir" => "/"
+        },
+        {
+          "alias"       => "not_valid_add_on",
+          "media_url"   => "http://media.url",
+          "name"        => "updated_repo",
+          "priority"    => 20,
+          "product_dir" => "/"
+        }
+      ]
+    end
+    let(:expected_output) do
+      [
+        "<ul>",
+        "<li>Media: http://product.url, Path: /, Product: </li>",
+        "<li>Media: http://media.url, Path: /, Product: </li>",
+        "</ul>"
+      ].join("\n")
     end
 
-    context "when 'func' is 'Reset'" do
-      let(:func) { "Reset" }
+    it "returns an unordered list sumarizing current add_on_product" do
+      allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
 
-      it "resets configuration" do
-        allow(Yast::AddOnProduct).to receive(:add_on_products=).with([])
-
-        subject.run
-      end
+      expect(subject.summary).to eq(expected_output)
     end
+  end
 
-    context "when 'func' is 'Change'" do
-      let(:func) { "Change" }
-
+  describe "#modified?" do
+    context "and configuration did changed" do
       before do
-        allow(Yast::Wizard).to receive(:CreateDialog)
-        allow(Yast::AutoinstSoftware).to receive(:pmInit)
+        allow(Yast::AddOnProduct).to receive(:modified).and_return(true)
       end
 
-      it "runs add-on main dialog" do
-        expect(subject).to receive(:RunAddOnMainDialog)
-
-        subject.run
-      end
-
-      it "returns chosen action" do
-        allow(subject).to receive(:RunAddOnMainDialog).and_return(:next)
-
-        expect(subject.run).to be(:next)
+      it "returns true" do
+        expect(subject.modified?).to be_truthy
       end
     end
 
-    context "when 'func' is 'Export'" do
-      let(:func) { "Export" }
+    context "and configuration did not changed" do
+      before do
+        allow(Yast::AddOnProduct).to receive(:modified).and_return(false)
+      end
 
-      # FIXME: use a more reallistic configuration data example
-      it "returns configuration data" do
-        allow(Yast::AddOnProduct).to receive(:Export).and_return("configuration data")
-
-        expect(subject.run).to eq("configuration data")
+      it "returns true" do
+        expect(subject.modified?).to be_falsey
       end
     end
+  end
 
-    context "when 'func' is 'Write'" do
-      let(:func) { "Write" }
-      let(:repos) do
+  describe "#modified" do
+    it "sets configuration as changed" do
+      allow(Yast::AddOnProduct).to receive(:modified=).with(true)
+
+      subject.modified
+    end
+  end
+
+  describe "#reset" do
+    it "resets configuration" do
+      allow(Yast::AddOnProduct).to receive(:add_on_products=).with([])
+
+      subject.reset
+    end
+  end
+
+  describe "#change" do
+    before do
+      allow(Yast::Wizard).to receive(:CreateDialog)
+      allow(Yast::AutoinstSoftware).to receive(:pmInit)
+    end
+
+    it "runs add-on main dialog" do
+      expect(subject).to receive(:RunAddOnMainDialog)
+
+      subject.change
+    end
+
+    it "returns chosen action" do
+      allow(subject).to receive(:RunAddOnMainDialog).and_return(:next)
+
+      expect(subject.change).to be(:next)
+    end
+  end
+
+  describe "#export" do
+    # FIXME: use a more reallistic configuration data example
+    it "returns configuration data" do
+      allow(Yast::AddOnProduct).to receive(:Export).and_return("configuration data")
+
+      expect(subject.export).to eq("configuration data")
+    end
+  end
+
+  describe "#write" do
+    let(:repos) do
+      [
+        {
+          "SrcId"        => 1,
+          "autorefresh"  => true,
+          "enabled"      => true,
+          "keeppackaged" => false,
+          "name"         => "repo_to_be_updated",
+          "priority"     => 99,
+          "service"      => ""
+        },
+        {
+          "SrcId"        => 2,
+          "autorefresh"  => true,
+          "enabled"      => true,
+          "keeppackaged" => false,
+          "name"         => "untouched_repo",
+          "priority"     => 99,
+          "service"      => ""
+        }
+      ]
+    end
+
+    context "when there are add-ons products" do
+      let(:ask_on_error) { true }
+      let(:add_on_products) do
+        [
+          {
+            "alias"        => "produc_alias",
+            "ask_on_error" => ask_on_error,
+            "media_url"    => "http://product.url",
+            "name"         => "updated_repo",
+            "priority"     => 20,
+            "product_dir"  => "/"
+          }
+        ]
+      end
+      let(:repos_to_store) do
         [
           {
             "SrcId"        => 1,
             "autorefresh"  => true,
             "enabled"      => true,
             "keeppackaged" => false,
-            "name"         => "repo_to_be_updated",
-            "priority"     => 99,
+            "name"         => "updated_repo",
+            "priority"     => 20,
             "service"      => ""
           },
           {
@@ -247,115 +256,73 @@ describe Yast::AddOnAutoClient do
         ]
       end
 
-      context "and there are add-ons products" do
-        let(:ask_on_error) { true }
-        let(:add_on_products) do
-          [
-            {
-              "alias"       => "produc_alias",
-              "ask_on_error"=> ask_on_error,
-              "media_url"   => "http://product.url",
-              "name"        => "updated_repo",
-              "priority"    => 20,
-              "product_dir" => "/"
-            }
-          ]
-        end
-        let(:repos_to_store) do
-          [
-            {
-              "SrcId"        => 1,
-              "autorefresh"  => true,
-              "enabled"      => true,
-              "keeppackaged" => false,
-              "name"         => "updated_repo",
-              "priority"     => 20,
-              "service"      => ""
-            },
-            {
-              "SrcId"        => 2,
-              "autorefresh"  => true,
-              "enabled"      => true,
-              "keeppackaged" => false,
-              "name"         => "untouched_repo",
-              "priority"     => 99,
-              "service"      => ""
-            }
-          ]
-        end
+      before do
+        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
+        allow(Yast::Pkg).to receive(:SourceEditSet)
+        allow(Yast::Pkg).to receive(:SourceCreate).and_return(1)
+        allow(Yast::Pkg).to receive(:SourceEditGet).and_return(repos)
+      end
 
-
+      # FIXME: improve that WIP scenarios/contexts
+      context "and product creation fails" do
         before do
-          allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
-          allow(Yast::Pkg).to receive(:SourceEditSet)
-          allow(Yast::Pkg).to receive(:SourceCreate).and_return(1)
-          allow(Yast::Pkg).to receive(:SourceEditGet).and_return(repos)
+          allow(Yast::Pkg).to receive(:SourceCreate).and_return(-1)
         end
 
-        # FIXME: improve that WIP scenarios/contexts
-        context "and product creation fails" do
+        context "ask_on_error=true" do
+          let(:ask_on_error) { true }
+
+          it "ask to make it available" do
+            expect(Yast::Popup).to receive(:ContinueCancel)
+
+            subject.write
+          end
+        end
+
+        context "ask_on_error=false" do
           before do
-            allow(Yast::Pkg).to receive(:SourceCreate).and_return(-1)
+            allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
           end
 
-          context "ask_on_error=true" do
-            let(:ask_on_error) { true }
+          let(:ask_on_error) { false }
 
-            it "ask to make it available" do
-              expect(Yast::Popup).to receive(:ContinueCancel)
+          it "report error" do
+            expect(Yast::Report).to receive(:Error)
 
-              subject.run
-            end
-          end
-
-
-          context "ask_on_error=false" do
-            before do
-              allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
-            end
-
-            let(:ask_on_error) { false }
-
-            it "report error" do
-              expect(Yast::Report).to receive(:Error)
-
-              subject.run
-            end
+            subject.write
           end
         end
+      end
 
-        it "stores repos according to information given" do
-          expect(Yast::Pkg).to receive(:SourceEditSet).with(repos_to_store)
+      it "stores repos according to information given" do
+        expect(Yast::Pkg).to receive(:SourceEditSet).with(repos_to_store)
 
-          subject.run
-        end
+        subject.write
+      end
+    end
+  end
+
+  describe "#read" do
+    context "when cannot lock package" do
+      before do
+        allow(Yast::PackageLock).to receive(:Check).and_return(false)
+      end
+
+      it "returns false" do
+        expect(subject.read).to be_falsey
       end
     end
 
-    context "when 'func' is 'Read'" do
-      let(:func) { "Read" }
-
-      context "and cannot lock package" do
-        before do
-          allow(Yast::PackageLock).to receive(:Check).and_return(false)
-        end
-
-        it "returns false" do
-          expect(subject.run).to be_falsey
-        end
+    context "when can lock package" do
+      before do
+        allow(Yast::PackageLock).to receive(:Check).and_return(true)
+        allow(Yast::Pkg).to receive(:SourceStartManager)
       end
 
-      context "and can lock package" do
-        before do
-          allow(Yast::PackageLock).to receive(:Check).and_return(true)
-          allow(Yast::Pkg).to receive(:SourceStartManager)
-        end
+      it "reads add-ons configuration from the current system" do
+        expect(subject).to receive(:ReadFromSystem)
 
-        it "reads add-ons configuration from the current system" do
-          expect(subject).to receive(:ReadFromSystem)
-
-          subject.run
-        end
+        subject.read
       end
     end
   end

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -12,11 +12,222 @@ describe Yast::AddOnAutoClient do
       allow(Yast::WFM).to receive(:Args).with(0).and_return(func)
     end
 
+    context "when 'func' is 'Import'" do
+      let(:func) { "Import" }
+      let(:params) do
+        { "add_on_products" => add_on_products }
+      end
+
+      before do
+        allow(Yast::WFM).to receive(:Args).with(no_args).and_return([func, params])
+        allow(Yast::WFM).to receive(:Args).with(1).and_return(params)
+      end
+
+      context "and completly valid 'add_on_products' param is given" do
+        let(:add_on_products) do
+          [
+            {
+              "alias"       => "valid_add_on",
+              "media_url"   => "http://product.url",
+              "name"        => "updated_repo",
+              "priority"    => 20,
+              "product_dir" => "/"
+            }
+          ]
+        end
+
+        it "imports all add-on products given" do
+          expect(Yast::AddOnProduct).to receive(:Import).with(params)
+
+          subject.main
+        end
+      end
+
+      context "and there are missed medie_url values in given 'add_on_products'" do
+        let(:add_on_products) do
+          [
+            {
+              "alias"       => "valid_add_on",
+              "media_url"   => "http://product.url",
+              "name"        => "updated_repo",
+              "priority"    => 20,
+              "product_dir" => "/"
+            },
+            {
+              "alias"       => "not_valid_add_on",
+              "name"        => "updated_repo",
+              "priority"    => 20,
+              "product_dir" => "/"
+            }
+          ]
+        end
+        let(:valid_add_on_products) do
+          [
+            {
+              "alias"       => "valid_add_on",
+              "media_url"   => "http://product.url",
+              "name"        => "updated_repo",
+              "priority"    => 20,
+              "product_dir" => "/"
+            }
+          ]
+        end
+
+        let(:rejected_package_error) { "Missing <media_url> value in the 2. add-on-product definition" }
+        let(:missed_media_url_error) { /Missing mandatory <media_url> value at index 2/ }
+
+        it "asks to user about reject them" do
+          expect(Yast::Popup).to receive(:ContinueCancel).with(missed_media_url_error)
+
+          subject.main
+        end
+
+        it "rejects them if user decides to continue" do
+          allow(Yast::Popup).to receive(:ContinueCancel).and_return(true)
+
+          expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => valid_add_on_products)
+
+          subject.main
+        end
+
+        it "returns false (does nothing) if user decides to abort" do
+          allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
+
+          expect(Yast::AddOnProduct).to_not receive(:Import)
+
+          # expect(subject.main).to be_falsey
+        end
+      end
+
+      context "and 'add_on_products' param is NOT given" do
+        let(:params) { { something: nil } }
+
+        # it "should does nothing" do
+        it "sets 'add_on_products' to empty array" do
+          expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => [])
+
+          subject.main
+        end
+      end
+    end
+
+    context "when 'func' is 'Summary'" do
+      let(:func) { "Summary" }
+      let(:add_on_products) do
+        [
+          {
+            "alias"       => "valid_add_on",
+            "media_url"   => "http://product.url",
+            "name"        => "updated_repo",
+            "priority"    => 20,
+            "product_dir" => "/"
+          },
+          {
+            "alias"       => "not_valid_add_on",
+            "media_url"   => "http://media.url",
+            "name"        => "updated_repo",
+            "priority"    => 20,
+            "product_dir" => "/"
+          }
+        ]
+      end
+      let(:expected_output) do
+        [
+          "<ul>",
+          "<li>Media: http://product.url, Path: /, Product: </li>",
+          "<li>Media: http://media.url, Path: /, Product: </li>",
+          "</ul>"
+        ].join("\n")
+      end
+
+      it "returns an unordered list sumarizing current add_on_product" do
+        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
+        expect(subject.main).to eq(expected_output)
+      end
+    end
+
+    context "when 'func' is 'GetModified'" do
+      let(:func) { "GetModified" }
+
+      context "and configuration did changed" do
+        before do
+          allow(Yast::AddOnProduct).to receive(:modified).and_return(true)
+        end
+
+        it "returns true" do
+          expect(subject.main).to be_truthy
+        end
+      end
+
+      context "and configuration did not changed" do
+        before do
+          allow(Yast::AddOnProduct).to receive(:modified).and_return(false)
+        end
+
+        it "returns true" do
+          expect(subject.main).to be_falsey
+        end
+      end
+    end
+
+    context "when 'func' is 'SetModified'" do
+      let(:func) { "SettModified" }
+
+      it "sets configuration as changed" do
+        allow(Yast::AddOnProduct).to receive(:modified=).with(true)
+
+        subject.main
+      end
+    end
+
+    context "when 'func' is 'Reset'" do
+      let(:func) { "Reset" }
+
+      it "resets configuration" do
+        allow(Yast::AddOnProduct).to receive(:add_on_products=).with([])
+
+        subject.main
+      end
+    end
+
+    context "when 'func' is 'Change'" do
+      let(:func) { "Change" }
+
+      before do
+        allow(Yast::Wizard).to receive(:CreateDialog)
+        allow(Yast::AutoinstSoftware).to receive(:pmInit)
+      end
+
+      it "runs add-on main dialog" do
+        expect(subject).to receive(:RunAddOnMainDialog)
+
+        subject.main
+      end
+
+      it "returns chosen action" do
+        allow(subject).to receive(:RunAddOnMainDialog).and_return(:next)
+
+        expect(subject.main).to be(:next)
+      end
+    end
+
+    context "when 'func' is 'Export'" do
+      let(:func) { "Export" }
+
+      # FIXME: use a more reallistinc configuration data example
+      it "returns configuration data" do
+        allow(Yast::AddOnProduct).to receive(:Export).and_return("configuration data")
+
+        expect(subject.main).to eq("configuration data")
+      end
+    end
+
     context "when 'func' is 'Write'" do
       let(:func) { "Write" }
       let(:repos) do
         [
-          { "SrcId"        => 1,
+          {
+            "SrcId"        => 1,
             "autorefresh"  => true,
             "enabled"      => true,
             "keeppackaged" => false,
@@ -83,6 +294,47 @@ describe Yast::AddOnAutoClient do
 
           subject.main
         end
+      end
+    end
+
+    context "when 'func' is 'Read'" do
+      let(:func) { "Read" }
+
+      context "and cannot lock package" do
+        before do
+          allow(Yast::PackageLock).to receive(:Check).and_return(false)
+        end
+
+        it "returns false" do
+          expect(subject.main).to be_falsey
+        end
+      end
+
+      context "and can lock package" do
+        before do
+          allow(Yast::PackageLock).to receive(:Check).and_return(true)
+          allow(Yast::Pkg).to receive(:SourceStartManager)
+        end
+
+        it "reads add-ons configuration from the current system" do
+          expect(subject).to receive(:ReadFromSystem)
+
+          subject.main
+        end
+      end
+    end
+
+    context "when 'fucn' is not valid" do
+      let(:func) { "Whatever" }
+
+      it "logs an `unknow function` error" do
+        allow(Yast::Builtins).to receive(:y2error).with("unknown function: %1", "Whatever")
+
+        subject.main
+      end
+
+      it "returns false" do
+        expect(subject.main).to be_falsey
       end
     end
   end

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -39,7 +39,7 @@ describe Yast::AddOnAutoClient do
       end
     end
 
-    context "when there are missed medie_url values in given 'add_on_products'" do
+    context "when there are missed media_url values in given 'add_on_products'" do
       let(:add_on_products) do
         [
           {
@@ -321,7 +321,7 @@ describe Yast::AddOnAutoClient do
   end
 
   describe "#read" do
-    context "when cannot lock package" do
+    context "when package manager cannot be locked" do
       before do
         allow(Yast::PackageLock).to receive(:Check).and_return(false)
       end
@@ -331,7 +331,7 @@ describe Yast::AddOnAutoClient do
       end
     end
 
-    context "when can lock package" do
+    context "when package manager can be locked" do
       before do
         allow(Yast::PackageLock).to receive(:Check).and_return(true)
         allow(Yast::Pkg).to receive(:SourceStartManager)

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -244,7 +244,7 @@ describe Yast::AddOnAutoClient do
           {
             "alias"        => "produc_alias",
             "ask_on_error" => ask_on_error,
-            "media_url"    => "http://product.url",
+            "media_url"    => "RELURL://product.url",
             "name"         => "updated_repo",
             "priority"     => 20,
             "product_dir"  => "/"

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -99,25 +99,43 @@ describe Yast::AddOnAutoClient do
       [
         {
           "alias"       => "valid_add_on",
+          "media_url"   => "dvd:///product",
+          "name"        => "updated_repo",
+          "priority"    => 20,
+          "product_dir" => "",
+        },
+        {
+          "alias"       => "valid_add_on",
           "media_url"   => "http://product.url",
           "name"        => "updated_repo",
           "priority"    => 20,
-          "product_dir" => "/"
+          "product_dir" => "/",
+          "product"     => "Example product"
         },
         {
           "alias"       => "not_valid_add_on",
-          "media_url"   => "http://media.url",
+          "media_url"   => "http://product.url",
           "name"        => "updated_repo",
           "priority"    => 20,
-          "product_dir" => "/"
+          "product_dir" => "/path/to/product"
+        },
+        {
+          "alias"       => "not_valid_add_on",
+          "media_url"   => "http://product.url",
+          "name"        => "updated_repo",
+          "priority"    => 20,
+          "product_dir" => "/path/to/product",
+          "product"     => "<strong>Example</strong> product"
         }
       ]
     end
     let(:expected_output) do
       [
         "<ul>",
-        "<li>Media: http://product.url, Path: /, Product: </li>",
-        "<li>Media: http://media.url, Path: /, Product: </li>",
+        "<li>URL: dvd:///product</li>",
+        "<li>URL: http://product.url, Product: Example product</li>",
+        "<li>URL: http://product.url, Path: /path/to/product</li>",
+        "<li>URL: http://product.url, Path: /path/to/product, Product: &lt;strong&gt;Example&lt;/strong&gt; product</li>",
         "</ul>"
       ].join("\n")
     end


### PR DESCRIPTION
This PR is a refactorization of auto add-on client, following the approach suggested by @imobachgs and @jreidinger in #52 and discarding the [first idea about refactoring only the #write method](https://github.com/dgdavid/yast-add-on/commit/8517e3fa558ff320ef5bdf76d9470b7aaf602de9).

Help is needed to finish it, especially with the test which probably needs improve a lot. Also, help with naming and documentation is welcome.

I will do a self-review to write down some doubts in place.