### PR TITLE
Required autoyast2-installation for building the package

### DIFF
--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -30,6 +30,7 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2 >= 3.0.1
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-packager
+BuildRequires:  autoyast2-installation
 Requires:       autoyast2-installation
 # ProductProfile
 Requires:       yast2 >= 3.0.1


### PR DESCRIPTION
The build of the packages is failing since the refactorization made in #54, this PR just adds the missing dependency.