### PR TITLE
AddOn auto client: Fixes import dependencies

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 27 11:11:21 UTC 2018 - knut.anderssen@suse.com
+
+- Fixing some import dependencies in the AddOn auto client
+  (bsc#1081509)
+- 4.1.4
+
+-------------------------------------------------------------------
 Mon Aug 27 07:03:03 UTC 2018 - knut.anderssen@suse.com
 
 - Do not show the main dialog when it is immediately skipped

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only
@@ -30,7 +30,6 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2 >= 3.0.1
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-packager
-BuildRequires:  autoyast2-installation
 Requires:       autoyast2-installation
 # ProductProfile
 Requires:       yast2 >= 3.0.1

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -1,8 +1,8 @@
 require "yast"
 require "installation/auto_client"
 
-Yast.import "AutoInstall"
 Yast.import "AddOnProduct"
+Yast.import "AutoinstSoftware"
 Yast.import "Progress"
 
 module Yast


### PR DESCRIPTION
It seems that `AutoInstall` is not needed at all, but the import of `AutoinstSofware` module was missing. The module was stubbed and that is why the test was not failing.

Removed again the autoyast2-installation build dependencies for speeding up the tests.