### PR TITLE
Fix AddOn auto client

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 30 08:50:09 UTC 2018 - dgonzalez@suse.com
+
+- Fix the run of AddOn auto client (bsc#1106536).
+- Add missing dependencies to the AddOn auto client.
+- 4.1.5
+
+-------------------------------------------------------------------
 Mon Aug 27 11:11:21 UTC 2018 - knut.anderssen@suse.com
 
 - Fixing some import dependencies in the AddOn auto client

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.4
+Version:        4.1.5
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/clients/add-on_auto.rb
+++ b/src/clients/add-on_auto.rb
@@ -1,3 +1,3 @@
 require "add-on/clients/add-on_auto"
 
-Yast::AddOnAutoClient.new.main
+Yast::AddOnAutoClient.new.run

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -3,6 +3,10 @@ require "installation/auto_client"
 
 Yast.import "AddOnProduct"
 Yast.import "AutoinstSoftware"
+Yast.import "Installation"
+Yast.import "Label"
+Yast.import "PackageCallbacks"
+Yast.import "PackageLock"
 Yast.import "Progress"
 
 module Yast
@@ -12,9 +16,9 @@ module Yast
 
       Yast.include self, "add-on/add-on-workflow.rb"
 
-      progress_orig = Yast::Progress.set(false)
+      progress_orig = Progress.set(false)
       ret = super
-      Yast::Progress.set(progress_orig)
+      Progress.set(progress_orig)
 
       ret
     end


### PR DESCRIPTION
Fix detected errors introduced in the AddOn auto client refactorization

  * Use `#run` instead the former `#main`
  * Bring back missed imports

---

Related to https://trello.com/c/48C6zsLV
