### PR TITLE
Fix the repo name selection

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 12 15:50:58 UTC 2018 - dgonzalez@suse.com
+
+- Fix and improve the repo name selection in the AddOn auto client
+  (bsc#1108139)
+- 4.1.6
+
+-------------------------------------------------------------------
 Thu Aug 30 08:50:09 UTC 2018 - dgonzalez@suse.com
 
 - Fix the run of AddOn auto client (bsc#1106536).

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -324,12 +324,12 @@ module Yast
       add_on_name = add_on.fetch("name", nil)
 
       # name in control file, bnc#433981
-      return add_on_name unless add_on_name.nil? || add_on_name.empty?
+      return add_on_name unless add_on_name.to_s.empty?
 
-      media = add_on.fetch("media")
-      product_dir = add_on.fetch("product_dir")
-      expanded_url = Pkg.ExpandedUrl(media)
-      repos_at_url = Pkg.RepositoryScan(expanded_url)
+      media_url = add_on.fetch("media_url", "")
+      product_dir = add_on.fetch("product_dir", "/")
+      expanded_url = Pkg.ExpandedUrl(media_url)
+      repos_at_url = Pkg.RepositoryScan(expanded_url) || []
 
       # {Pkg.RepositoryScan} output: [["Product Name", "Path"], ...]
       found_repo = repos_at_url.find { |r| r[1] == product_dir }

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -245,7 +245,6 @@ describe Yast::AddOnAutoClient do
             "alias"        => "produc_alias",
             "ask_on_error" => ask_on_error,
             "media_url"    => "RELURL://product.url",
-            "name"         => "updated_repo",
             "priority"     => 20,
             "product_dir"  => "/"
           }
@@ -258,7 +257,7 @@ describe Yast::AddOnAutoClient do
             "autorefresh"  => true,
             "enabled"      => true,
             "keeppackaged" => false,
-            "name"         => "updated_repo",
+            "name"         => "Updated repo",
             "priority"     => 20,
             "service"      => ""
           },
@@ -279,9 +278,13 @@ describe Yast::AddOnAutoClient do
         allow(Yast::Pkg).to receive(:SourceEditSet)
         allow(Yast::Pkg).to receive(:SourceCreate).and_return(1)
         allow(Yast::Pkg).to receive(:SourceEditGet).and_return(repos)
+        allow(Yast::Pkg).to receive(:ExpandedUrl)
+        # To test indirectly the "preferred_name_for" method
+        allow(Yast::Pkg).to receive(:RepositoryScan)
+          .with(anything)
+          .and_return([["Updated repo", "/"]])
       end
 
-      # FIXME: improve that WIP scenarios/contexts
       context "and product creation fails" do
         before do
           allow(Yast::Pkg).to receive(:SourceCreate).and_return(-1)


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1108139

---

During [the AddOn auto client refactorization](https://github.com/yast/yast-add-on/pull/54) a typo was introduced at the time to get the repo name, asking for `media` key instead of the right `media_url`. In addition, also the default value for `.fetch` was forgotten.

This PR fix those bugs and the implied test has been adapted a little to ensure a minimum coverage of the `preferred_name_for` method.