### PR TITLE
 Fixed displaying previous dialog content (bsc#1117492)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 14 17:13:20 UTC 2018 - lslezak@suse.cz
+
+- Fixed displaying previous dialog content when going back and
+  forth in the installation workflow (bsc#1117492)
+- 4.1.10
+
+-------------------------------------------------------------------
 Fri Nov 23 17:08:05 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.9
+Version:        4.1.10
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1021,13 +1021,8 @@ module Yast
           # because of CD/DVD + url cd://
           Pkg.SourceReleaseAll
 
-          # bugzilla #305788
-          # Use new wizard window for adding new Add-On.
-          # Do not use "Steps" dialog.
-          Wizard.OpenLeftTitleNextBackDialog
           Wizard.SetTitleIcon("yast-addon")
           ret2 = RunWizard()
-          Wizard.CloseDialog
 
           log.info "Subworkflow result: ret2: #{ret2}"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,9 @@ end
 # Stub classes from other modules to speed up a build
 stub_module("AutoinstGeneral")
 stub_module("AutoinstSoftware")
+# the SuSEFirewall module checks the firewall status in the constructor,
+# avoid displaying a PolicyKit popup asking for the root password...
+stub_module("SuSEFirewall")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
- [Bug #1117492](https://bugzilla.suse.com/show_bug.cgi?id=1117492)
- Originally the code displayed a new dialog on top of the current one. After closing the dialog the previous one was displayed for a short while, before it got replaced by the content of the next dialog.
- This is the real fix for the bug, the previous one was not enough when going back
  - The referenced bug [#305788](https://bugzilla.suse.com/show_bug.cgi?id=305788) does not seem to be valid anymore, I did not see any problem after removing that 11+ years old fix

## Original Screecast

- Originally the partitioning dialog was displayed for a short while after going back in the add-on dialog

![going_back_original](https://user-images.githubusercontent.com/907998/50077729-7e52b980-01e5-11e9-97a8-1f551a1d6b82.gif)

## Fixed Workflow

- Now the partitioner dialog is not displayed anymore

![going_back](https://user-images.githubusercontent.com/907998/50078325-f372be80-01e6-11e9-8714-732a15a6d542.gif)


## Fixed Tests

- Additionally fixed testsuite to not display PolicyKit popup 

![firewall-polkit](https://user-images.githubusercontent.com/907998/50077578-113f2400-01e5-11e9-83e6-34f143290dd0.png)
