### PR TITLE
[master] Do not abort the installation when an addon EULA is refused

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  1 07:40:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not abort when an addon license is refused (bsc#1114018).
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:23:30 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only
@@ -38,8 +38,8 @@ Requires:       autoyast2-installation
 Requires:       yast2 >= 3.0.1
 Requires:       yast2-country
 Requires:       yast2-installation
-# new AddOnProduct.DoInstall argument
-Requires:       yast2-packager >= 4.0.25
+# Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
+Requires:       yast2-packager >= 4.2.16
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Obsoletes:      yast2-add-on-devel-doc

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1027,6 +1027,9 @@ module Yast
           Wizard.SetTitleIcon("yast-addon")
           ret2 = RunWizard()
 
+          break if ret2 == :back
+          return :abort if ret2 == :abort
+
           log.info "Subworkflow result: ret2: #{ret2}"
 
           if ret2 == :next
@@ -1052,7 +1055,7 @@ module Yast
             # Release all sources after adding a new one
             # because of CD/DVD + url cd://
             Pkg.SourceReleaseAll
-          elsif ret2 == :abort || ret2 == :cancel
+          elsif ret2 == :cancel
             log.info("Aborted, removing add-on repositories: #{@added_repos.inspect}")
 
             # remove the repository


### PR DESCRIPTION
### :warning: Similar to https://github.com/yast/yast-add-on/pull/78, but for `master` (aka SLE-15-SP2) :warning: ###

## Problem

When user refuses an addon's EULA (doing click in "Next" without check the _I Agree to the License Terms._) the installation is completely aborted.

* https://bugzilla.suse.com/show_bug.cgi?id=1114018
* https://trello.com/c/Kc9mRVpB

## Solution

In spite of in the current code there is an intentional (and broken) behavior to

> **just go ahead _refusing_ the license and not installing/registering the addon**, according to the message shown to the user.

<details>
<summary>Show/hide screenshot</summary>

---

![Screenshot_sles12-sp4_2019-06-19_11_28_47](https://user-images.githubusercontent.com/1691872/59758426-d1392680-9285-11e9-914c-e7bca8ebc6af.png)
<small>The message shown to the user, from an SLE-12 Screenshot (still being the same)</small>

---
</details>

To do that, it has been necessary to update `yast2-packager` too (see https://github.com/yast/yast-packager/pull/456), in order to support "refuse" as a cancel action. Otherwise, it is not possible to distinguish when the "abort" means "to refuse the license agreement" or "abort the installation".

## Tests

* *Only* tested manually via driver update.