### PR TITLE
Update yast2-packager dependency

### DIFF
--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -35,8 +35,8 @@ Requires:       autoyast2-installation
 Requires:       yast2 >= 3.0.1
 Requires:       yast2-country
 Requires:       yast2-installation
-# new AddOnProduct.DoInstall argument
-Requires:       yast2-packager >= 4.0.25
+# Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
+Requires:       yast2-packager >= 4.1.47
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Obsoletes:      yast2-add-on-devel-doc


### PR DESCRIPTION
> Forgotten in 08fe350872915c3c8772d2776491b8a27cfec6ed

To be able to [_Do not abort the installation when an addon EULA is refused_](https://github.com/yast/yast-add-on/pull/78), the `yast2-packager >=` [`4.1.47`](https://github.com/yast/yast-packager/pull/456) is required.