### PR TITLE
User defined add-ons

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Jul  9 17:42:52 CEST 2019 - schubi@suse.de
 
-- AY Export/Import: Support user defined repos (bsc#1125441)
+- AY Export/Import: Support of user defined repos (bsc#1125441).
 - 4.2.2
 
 -------------------------------------------------------------------

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  9 17:42:52 CEST 2019 - schubi@suse.de
+
+- AY Export/Import: Support user defined repos (bsc#1125441)
+- 4.2.2
+
+-------------------------------------------------------------------
 Mon Jul  1 07:40:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not abort when an addon license is refused (bsc#1114018).

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Tue Jul  9 17:42:52 CEST 2019 - schubi@suse.de
 
-- AY Export/Import: Support of user defined repos (bsc#1125441).
+- AY Export/Import: Support also repositories not containing any
+  product (usually custom or 3rd party repositories) (bsc#1125441).
 - 4.2.2
 
 -------------------------------------------------------------------

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only
@@ -65,6 +65,7 @@ This package contains YaST Add-On media installation code.
 %{yast_yncludedir}
 %{yast_libdir}
 %{yast_clientdir}
+%{yast_moduledir}
 %{yast_desktopdir}
 %{yast_metainfodir}
 %{yast_schemadir}

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -31,7 +31,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2 >= 3.0.1
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2-packager
+# Y2packager::Resolvables
+BuildRequires:  yast2-packager >= 4.2.11
 
 Requires:       autoyast2-installation
 # ProductProfile

--- a/src/autoyast-rnc/add-on.rnc
+++ b/src/autoyast-rnc/add-on.rnc
@@ -3,7 +3,10 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
 add-on =
-  element add-on { add_on_products* }
+  element add-on {
+      add_on_products* &
+      add_on_others*
+  }
 listentry =
   element listentry {
      media_url & # here it is mandatory
@@ -54,3 +57,8 @@ add_on_products =
      attribute config:type { text }?,
      listentry*
   }
+add_on_others =
+  element add_on_others {
+     attribute config:type { text }?,
+     listentry*
+  }  

--- a/src/clients/add-on_proposal.rb
+++ b/src/clients/add-on_proposal.rb
@@ -32,13 +32,13 @@ module Yast
         @items = Builtins.maplist(AddOnProduct.add_on_products) do |product|
           data = Pkg.SourceGeneralData(Ops.get_integer(product, "media", -1))
           # placeholder for unknown path
-          dir = Ops.get_locale(data, "product_dir", _("Unknown"))
+          dir = Ops.get_locale(data, "product_dir", product.fetch( "product_dir", _("Unknown")))
           dir = "/" if dir == ""
           # summary item, %1 is product name, %2 media URL, %3 directory on media
           Builtins.sformat(
             "%1 (Media %2, directory %3)",
             Ops.get_string(product, "product", ""),
-            Ops.get_locale(data, "url", _("Unknown")),
+            Ops.get_locale(data, "url", product.fetch( "media_url", _("Unknown"))),
             dir
           )
         end

--- a/src/clients/add-on_proposal.rb
+++ b/src/clients/add-on_proposal.rb
@@ -37,7 +37,7 @@ module Yast
           # summary item, %1 is product name, %2 media URL, %3 directory on media
           Builtins.sformat(
             "%1 (Media %2, directory %3)",
-            Ops.get_string(product, "product", ""),
+            Ops.get_string(product, "product", _("No name defined")),
             Ops.get_locale(data, "url", product.fetch( "media_url", _("Unknown"))),
             dir
           )

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -26,7 +26,7 @@ module Yast
 
     def import(data)
       add_ons = data.fetch("add_on_products", [])
-      # add-on prducts have the same format as add-ons which have been
+      # Add-on products have the same format as add-ons which have been
       # added manually by the user. So we can take the same workflow here.
       add_ons += data.fetch("add_on_others", [])
 
@@ -47,7 +47,7 @@ module Yast
     # Returns an unordered HTML list summarizing the Add-on products
     #
     # Each item will contain information about
-    # 
+    #
     #   * URL, the "media_url" property
     #   * Path, the "product_dir" property which will be omitted wether is not present or is the default
     #           path ("/")
@@ -170,7 +170,7 @@ module Yast
 
       ReadFromSystem()
 
-      # reading none product repos
+      # Reading user defined repos
       AddOnOthers.Read()
     end
 

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "yast"
+require "y2packager/resolvable"
 
 # Yast namespace
 module Yast
@@ -30,12 +31,11 @@ module Yast
     def Read
       # Removing all repos which have installed based products
       # and add-on products.
-      all_products = Pkg.ResolvableProperties("", :product, "")
+      all_products = Y2Packager::Resolvable.find(kind: :product, status: :available)
       installed_products = all_products.select do |p|
-        p["status"] == :available &&
-        all_products.any? { |s| s["name"] == p["name"] && s["status"] == :installed }
+        Y2Packager::Resolvable.any?(kind: :product, status: :installed, name: p.name)
       end
-      installed_src_ids = installed_products.map{ |p| p["source"] }.uniq
+      installed_src_ids = installed_products.map{ |p| p.source }.uniq
       other_repo_ids = Pkg.SourceGetCurrent(true) - installed_src_ids
       @add_on_others = other_repo_ids.map{ |id| Pkg.SourceGeneralData(id) }
     end

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -23,7 +23,7 @@ module Yast
 
     def main
       Yast.import "Pkg"
-      textdomain "packager"      
+      textdomain "add-on"
 
       @add_on_others = []
     end
@@ -31,12 +31,12 @@ module Yast
     def Read
       # Removing all repos which have installed based products
       # and add-on products.
-      all_products = Y2Packager::Resolvable.find(kind: :product)
-      installed_products = all_products.select do |p|
-        p.status == :available &&
-        all_products.any? { |s| s.name == p.name && s.status == :installed }
+      installed_product_names = Y2Packager::Resolvable.find(kind: :product, status: :installed).map(&:name)
+      installed_available_products = Y2Packager::Resolvable.find(kind: :product, status: :available).select do |p|
+        installed_product_names.include?(p.name)
       end
-      installed_src_ids = installed_products.map{ |p| p.source }.uniq
+
+      installed_src_ids = installed_available_products.map(&:source).uniq
       other_repo_ids = Pkg.SourceGetCurrent(true) - installed_src_ids
       @add_on_others = other_repo_ids.map{ |id| Pkg.SourceGeneralData(id) }
     end

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -28,7 +28,7 @@ module Yast
     end
 
     def Read
-      # Removing all repos which have installed based
+      # Removing all repos which have installed based products
       # and add-on products.
       all_products = Pkg.ResolvableProperties("", :product, "")
       installed_products = all_products.select do |p|
@@ -40,9 +40,9 @@ module Yast
       @add_on_others = other_repo_ids.map{ |id| Pkg.SourceGeneralData(id) }
     end
 
-    # Returns has describing all used added repos which are not base products or add-ons
+    # Returns all enabled user added repos which are not base products or add-on products.
     #
-    # @return [Hash]
+    # @return [Hash] User defined repos.
     #
     # @example This is an XML file created from exported map:
     #      <add-on>

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -29,13 +29,13 @@ module Yast
     
 
     def Read
-      @add_on_others = []
-      
       # Removing all repos which have installed based
       # and add-on products.
-      installed_products = Pkg.ResolvableProperties("", :product, "").select do |p|
+      all_products = Pkg.ResolvableProperties("", :product, "")
+      installed_products = all_products.select do |p|
         p["status"] == :available &&
-        Pkg.ResolvableProperties(p["name"], :product, "").any? { |s| s["status"] == :installed }              end
+        all_products.any? { |s| s["name"] == p["name"] && s["status"] == :installed }
+      end
       installed_src_ids = installed_products.map{ |p| p["source"] }.uniq
       other_repo_ids = Pkg.SourceGetCurrent(true) - installed_src_ids
       @add_on_others = other_repo_ids.map{ |id| Pkg.SourceGeneralData(id) }

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+require "yast"
+
+# Yast namespace
+module Yast
+  # This module provides integration of the add-on products
+
+  class AddOnOthersClass < Module
+           
+    include Yast::Logger
+
+    #     add_on_others = [
+    #        {
+    #          "media" => 4, # ID of the source
+    #          "name" : "openSUSE version XX.Y",
+    #          "media_url"=>"dvd:/?devices=/dev/sr1"
+    #          ....
+    #        },
+    #        ...
+    #      ]
+    attr_reader :add_on_others
+
+    def main
+      Yast.import "Pkg"
+      textdomain "packager"      
+
+      @add_on_others = []
+    end
+    
+
+    def Read
+      @add_on_others = []
+      
+      # Removing all repos which have installed based
+      # and add-on products.
+      installed_products = Pkg.ResolvableProperties("", :product, "").select do |p|
+        p["status"] == :available &&
+        Pkg.ResolvableProperties(p["name"], :product, "").any? { |s| s["status"] == :installed }              end
+      installed_src_ids = installed_products.map{ |p| p["source"] }.uniq
+      other_repo_ids = Pkg.SourceGetCurrent(true) - installed_src_ids
+      @add_on_others = other_repo_ids.map{ |id| Pkg.SourceGeneralData(id) }
+    end
+
+    # Returns has describing all used added repos which are not base products or add-ons
+    #
+    # @return [Hash]
+    #
+    # @example This is an XML file created from exported map:
+    #      <add-on>
+    #        <add_on_others config:type="list">
+    #          <listentry>
+    #            <media_url>ftp://server.name/.../</media_url>
+    #            <alias>alias name</alias>
+    #            <priority config:type="integer">20</priority>
+    #            <name>Repository name</name>
+    #            <product_dir>/</product_dir>
+    #          </listentry>
+    #          ...
+    #        </add_on_others>
+    #      </add-on>
+    def Export
+      others = @add_on_others.map do |p|
+        { "media_url"   => p["url"],
+          "alias"       => p["alias"],
+          "priority"    => p["priority"],
+          "name"        => p["name"],
+          "product_dir" => p["product_dir"] }
+      end
+      { "add_on_others" => others }
+    end
+
+    publish function: :Export, type: "map ()"
+    publish function: :Read, type: "map()"
+  end
+
+  AddOnOthers = AddOnOthersClass.new
+  AddOnOthers.main
+
+end
+

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -26,7 +26,6 @@ module Yast
 
       @add_on_others = []
     end
-    
 
     def Read
       # Removing all repos which have installed based
@@ -75,6 +74,5 @@ module Yast
 
   AddOnOthers = AddOnOthersClass.new
   AddOnOthers.main
-
 end
 

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -31,9 +31,10 @@ module Yast
     def Read
       # Removing all repos which have installed based products
       # and add-on products.
-      all_products = Y2Packager::Resolvable.find(kind: :product, status: :available)
+      all_products = Y2Packager::Resolvable.find(kind: :product)
       installed_products = all_products.select do |p|
-        Y2Packager::Resolvable.any?(kind: :product, status: :installed, name: p.name)
+        p.status == :available &&
+        all_products.any? { |s| s.name == p.name && s.status == :installed }
       end
       installed_src_ids = installed_products.map{ |p| p.source }.uniq
       other_repo_ids = Pkg.SourceGetCurrent(true) - installed_src_ids

--- a/test/addon_others_test.rb
+++ b/test/addon_others_test.rb
@@ -6,7 +6,7 @@ Yast.import "AddOnOthers"
 describe Yast::AddOnOthers do
   subject { Yast::AddOnOthers }
   
-  let(:products) do
+  let(:available_products) do
     [ Y2Packager::Resolvable.new(kind: :product,
         name: "SLE_RT", status: :available, source: 2 ),
       Y2Packager::Resolvable.new(kind: :product,
@@ -22,15 +22,9 @@ describe Yast::AddOnOthers do
       Y2Packager::Resolvable.new(kind: :product,
         name: "SUSE-Manager-Proxy", status: :available, source: 2 ),
       Y2Packager::Resolvable.new(kind: :product,
-        name: "sle-module-desktop-applications", status: :installed, source: -1 ),
-      Y2Packager::Resolvable.new(kind: :product,
         name: "sle-module-desktop-applications", status: :available, source: 1 ),
       Y2Packager::Resolvable.new(kind: :product,
-        name: "sle-module-basesystem", status: :installed, source: -1 ),
-      Y2Packager::Resolvable.new(kind: :product,
         name: "sle-module-basesystem", status: :available, source: 0 ),
-      Y2Packager::Resolvable.new(kind: :product,
-        name: "SLES", status: :installed, source: -1 ),
       Y2Packager::Resolvable.new(kind: :product,
         name: "SLES", status: :available, source: 3 ),
       Y2Packager::Resolvable.new(kind: :product,
@@ -39,6 +33,17 @@ describe Yast::AddOnOthers do
         name: "SUSE-Manager-Retail-Branch-Server", status: :available, source: 2 )
     ]
   end
+
+  let(:installed_products) do
+    [ Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-desktop-applications", status: :installed, source: -1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-basesystem", status: :installed, source: -1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SLES", status: :installed, source: -1 ),
+    ]
+  end
+
   let(:repo_hash) do
     { "alias"       => "user defined",
       "url"         => "http://xxx.url",
@@ -49,8 +54,10 @@ describe Yast::AddOnOthers do
   end
 
   before do
-    allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
-      .and_return(products)
+    allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :available)
+      .and_return(available_products)
+    allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :installed)
+      .and_return(installed_products)
     allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true)
       .and_return([0,1,2,3,4])
   end

--- a/test/addon_others_test.rb
+++ b/test/addon_others_test.rb
@@ -50,7 +50,7 @@ describe Yast::AddOnOthers do
   end
 
   before do
-    allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+    allow(Y2Packager::Resolvable).to receive(:find)with(kind: :product)
       .and_return(products)
     allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true)
       .and_return([0,1,2,3,4])

--- a/test/addon_others_test.rb
+++ b/test/addon_others_test.rb
@@ -1,0 +1,90 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+Yast.import "AddOnOthers"
+
+describe Yast::AddOnOthers do
+  subject { Yast::AddOnOthers }
+  
+  let(:products) do
+    [
+      { "name" => "SLE_RT",
+        "status" => :available, "source" => 2 },
+      { "name" => "SLE_HPC",
+        "status" => :available, "source" => 2 },
+      { "name" => "SLE_SAP",
+        "status" => :available, "source" => 2 },
+      { "name" => "SLE_BCL",
+        "status" => :available, "source" => 2 },
+      { "name" => "SLED",
+        "status" => :available, "source" => 2 },
+      { "name" => "SUSE-Manager-Server",
+        "status" => :available, "source" => 2 },
+      { "name" => "SUSE-Manager-Proxy",
+        "status" => :available, "source" => 2 },
+      { "name" => "sle-module-desktop-applications",
+        "status" => :installed, "source" => -1 },
+      { "name" => "sle-module-desktop-applications",
+        "status" => :available, "source" => 1 },
+      { "name" => "sle-module-basesystem",
+        "status" => :installed, "source" => -1 },
+      { "name" => "sle-module-basesystem",
+        "status" => :available, "source" => 0 },
+      { "name" => "SLES",
+        "status" => :installed, "source" => -1 },
+      { "name" => "SLES",
+        "status" => :available, "source" => 3 },
+      { "name" => "SLES",
+        "status" => :available, "source" => 2 },
+      { "name" => "SUSE-Manager-Retail-Branch-Server",
+        "status" => :available, "source" => 2 }
+    ]
+  end
+  let(:repo_hash) do
+    { "alias"       => "user defined",
+      "url"         => "http://xxx.url",
+      "name"        => "user_defined",
+      "priority"    => 19,
+      "product_dir" => "/"
+    }    
+  end
+
+  before do
+    allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      .and_return(products)
+    allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true)
+      .and_return([0,1,2,3,4])
+  end
+      
+  describe "#Read" do
+   
+    context "installed products and add-ons are available" do
+    
+      it "returns user defined repo only" do
+        expect(Yast::Pkg).to receive(:SourceGeneralData).with(4)
+          .and_return(repo_hash)
+        expect(Yast::AddOnOthers.Read).to eq([repo_hash])
+      end
+    end
+  end
+
+  describe "#Export" do
+   
+    context "installed products and add-ons are available" do
+      let(:ret) do
+        { "media_url"   => repo_hash["url"],
+          "alias"       => repo_hash["alias"],
+          "priority"    => repo_hash["priority"],
+          "name"        => repo_hash["name"],
+          "product_dir" => repo_hash["product_dir"] }        
+      end
+    
+      it "returns an array of user defined repos in AY format" do
+        allow(Yast::Pkg).to receive(:SourceGeneralData).with(4)
+          .and_return(repo_hash)
+        Yast::AddOnOthers.Read()
+        expect(Yast::AddOnOthers.Export).to eq({ "add_on_others" => [ret] })
+      end
+    end
+  end  
+end

--- a/test/addon_others_test.rb
+++ b/test/addon_others_test.rb
@@ -7,37 +7,36 @@ describe Yast::AddOnOthers do
   subject { Yast::AddOnOthers }
   
   let(:products) do
-    [
-      { "name" => "SLE_RT",
-        "status" => :available, "source" => 2 },
-      { "name" => "SLE_HPC",
-        "status" => :available, "source" => 2 },
-      { "name" => "SLE_SAP",
-        "status" => :available, "source" => 2 },
-      { "name" => "SLE_BCL",
-        "status" => :available, "source" => 2 },
-      { "name" => "SLED",
-        "status" => :available, "source" => 2 },
-      { "name" => "SUSE-Manager-Server",
-        "status" => :available, "source" => 2 },
-      { "name" => "SUSE-Manager-Proxy",
-        "status" => :available, "source" => 2 },
-      { "name" => "sle-module-desktop-applications",
-        "status" => :installed, "source" => -1 },
-      { "name" => "sle-module-desktop-applications",
-        "status" => :available, "source" => 1 },
-      { "name" => "sle-module-basesystem",
-        "status" => :installed, "source" => -1 },
-      { "name" => "sle-module-basesystem",
-        "status" => :available, "source" => 0 },
-      { "name" => "SLES",
-        "status" => :installed, "source" => -1 },
-      { "name" => "SLES",
-        "status" => :available, "source" => 3 },
-      { "name" => "SLES",
-        "status" => :available, "source" => 2 },
-      { "name" => "SUSE-Manager-Retail-Branch-Server",
-        "status" => :available, "source" => 2 }
+    [ Y2Packager::Resolvable.new(kind: :product,
+        name: "SLE_RT", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SLE_HPC", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,                  
+        name: "SLE_SAP", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,                  
+        name: "SLE_BCL", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,                  
+        name: "SLED", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,                     
+        name: "SUSE-Manager-Server", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SUSE-Manager-Proxy", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-desktop-applications", status: :installed, source: -1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-desktop-applications", status: :available, source: 1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-basesystem", status: :installed, source: -1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "sle-module-basesystem", status: :available, source: 0 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SLES", status: :installed, source: -1 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SLES", status: :available, source: 3 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SLES", status: :available, source: 2 ),
+      Y2Packager::Resolvable.new(kind: :product,
+        name: "SUSE-Manager-Retail-Branch-Server", status: :available, source: 2 )
     ]
   end
   let(:repo_hash) do
@@ -50,7 +49,7 @@ describe Yast::AddOnOthers do
   end
 
   before do
-    allow(Y2Packager::Resolvable).to receive(:find)with(kind: :product)
+    allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
       .and_return(products)
     allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true)
       .and_return([0,1,2,3,4])

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -8,7 +8,9 @@ Yast.import "Packages"
 describe Yast::AddOnAutoClient do
   describe "#import" do
     let(:params) do
-      { "add_on_products" => add_on_products }
+      { "add_on_products" => add_on_products
+#        ,"add_on_others" => add_on_others
+      }
     end
 
     context "when 'add_on_products' param is NOT given" do
@@ -18,6 +20,15 @@ describe Yast::AddOnAutoClient do
         subject.import(something: nil)
       end
     end
+=begin
+    context "when 'add_on_others' param is NOT given" do
+      it "sets 'add_on_others' to empty array" do
+        expect(Yast::AddOnOthers).to receive(:Import).with("add_on_others" => [])
+
+        subject.import(something: nil)
+      end
+    end
+=end
 
     context "when completly valid 'add_on_products' param is given" do
       let(:add_on_products) do
@@ -205,11 +216,23 @@ describe Yast::AddOnAutoClient do
   end
 
   describe "#export" do
-    # FIXME: use a more reallistic configuration data example
-    it "returns configuration data" do
-      allow(Yast::AddOnProduct).to receive(:Export).and_return("configuration data")
+    let(:add_on_products) do
+      {"add_on_products"=> [
+        { "product_dir"=>"/Module-Desktop-Applications",
+          "product"=>"sle-module-desktop-applications",
+          "media_url"=>"dvd:/?devices=/dev/sr1" },
+        { "product_dir"=>"/Module-Basesystem",
+          "product"=>"sle-module-basesystem",
+          "media_url"=>"dvd:/?devices=/dev/sr1" }
+      ]}
+    end
+    let(:add_on_others) { {"add_on_others"=>[]} }
 
-      expect(subject.export).to eq("configuration data")
+    it "returns add-on products and other user defined add-ons" do
+      expect(Yast::AddOnProduct).to receive(:Export).and_return(add_on_products)
+      expect(Yast::AddOnOthers).to receive(:Export).and_return(add_on_others)
+
+      expect(subject.export).to eq(add_on_products.merge(add_on_others))
     end
   end
 

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -8,8 +8,8 @@ Yast.import "Packages"
 describe Yast::AddOnAutoClient do
   describe "#import" do
     let(:params) do
-      { "add_on_products" => add_on_products
-#        ,"add_on_others" => add_on_others
+      { "add_on_products" => add_on_products,
+        "add_on_others" => add_on_others
       }
     end
 
@@ -20,15 +20,6 @@ describe Yast::AddOnAutoClient do
         subject.import(something: nil)
       end
     end
-=begin
-    context "when 'add_on_others' param is NOT given" do
-      it "sets 'add_on_others' to empty array" do
-        expect(Yast::AddOnOthers).to receive(:Import).with("add_on_others" => [])
-
-        subject.import(something: nil)
-      end
-    end
-=end
 
     context "when completly valid 'add_on_products' param is given" do
       let(:add_on_products) do
@@ -43,8 +34,21 @@ describe Yast::AddOnAutoClient do
         ]
       end
 
+      let(:add_on_others) do
+        [
+          {
+            "alias"       => "user defined",
+            "media_url"   => "http://xxx.url",
+            "name"        => "user_defined",
+            "priority"    => 19,
+            "product_dir" => "/"
+          }
+        ]
+      end
+
       it "imports all add-on products given" do
-        expect(Yast::AddOnProduct).to receive(:Import).with(params)
+        expect(Yast::AddOnProduct).to receive(:Import).with(
+          { "add_on_products" => add_on_products + add_on_others})
 
         subject.import(params)
       end
@@ -79,6 +83,7 @@ describe Yast::AddOnAutoClient do
           }
         ]
       end
+      let(:add_on_others) { [] }
 
       let(:rejected_package_error) { "Missing <media_url> value in the 2. add-on-product definition" }
       let(:missed_media_url_error) { /Missing mandatory <media_url> value at index 2/ }


### PR DESCRIPTION
With that PR we would have that solution in the AY configuration file.

```xml
<add-on>
  <add_on_others config:type="list">
    <listentry>
      <alias>yast_head</alias>
      <media_url>https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Leap_15.1/\</media_url>
      <name>Yast head</name>
      <priority config:type="integer">99</priority>
      <product_dir>/</product_dir>
    </listentry>
  </add_on_others>
  <add_on_products config:type="list">
    <listentry>
      <media_url>dvd:/?devices=/dev/sr1</media_url>
      <product>sle-module-desktop-applications</product>
      <product_dir>/Module-Desktop-Applications</product_dir>
    </listentry>
    <listentry>
      <media_url>dvd:/?devices=/dev/sr1</media_url>
      <product>sle-module-basesystem</product>
      <product_dir>/Module-Basesystem</product_dir>
    </listentry>
  </add_on_products>

</add-on>
```

The general question has raised up, if we still keep that "meaning" of add-ons, or if we should simplify the structure.