### PR TITLE
Release the sources to avoid using up all server connections 

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 25 08:40:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Release the sources to avoid using up all server connections
+  (bsc#1141127)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue Jul  9 17:42:52 CEST 2019 - schubi@suse.de
 
 - AY Export/Import: Support also repositories not containing any

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -196,6 +196,7 @@ module Yast
 
       loop do
         source_id = Pkg.SourceCreate(url, product_dir)
+        Pkg.SourceReleaseAll
 
         log.info("New source ID: #{source_id}")
 
@@ -210,6 +211,7 @@ module Yast
         else
           # bugzilla #260613
           AddOnProduct.Integrate(source_id)
+          Pkg.SourceReleaseAll
 
           adjust_source_attributes(add_on, source_id)
           install_product(product)

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -304,6 +304,7 @@ describe Yast::AddOnAutoClient do
       before do
         allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
         allow(Yast::Pkg).to receive(:SourceEditSet)
+        allow(Yast::Pkg).to receive(:SourceReleaseAll)
         allow(Yast::Pkg).to receive(:SourceCreate).and_return(1)
         allow(Yast::Pkg).to receive(:SourceEditGet).and_return(repos)
         allow(Yast::Pkg).to receive(:ExpandedUrl)
@@ -345,6 +346,12 @@ describe Yast::AddOnAutoClient do
 
       it "stores repos according to information given" do
         expect(Yast::Pkg).to receive(:SourceEditSet).with(repos_to_store)
+
+        subject.write
+      end
+
+      it "releases the media accessors" do
+        expect(Yast::Pkg).to receive(:SourceReleaseAll)
 
         subject.write
       end


### PR DESCRIPTION
## The Problem

- When serving the SLE15 modules via a local FTP server AutoYaST gets errors when adding the modules (server timeout errors)
- See https://bugzilla.suse.com/show_bug.cgi?id=1141127
- In reality these are "too many connections" errors, the server has a low limit for the maximum number of connections from the same IP

## The Solution

- We need to call the `Pkg.SourceReleaseAll` call to release the libzypp media accessors

## Tests

- Tested manually with an FTP server configured with max. 3 connections per IP, AutoYaST could add 15 repositories (modules) without any problem.
- Added an unit test