### PR TITLE
Automatically offer the addons from the offline medium (jsc#SLE-7101)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 30 07:50:24 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Automatically offer the modules and extensions in the offline
+  media installation (jsc#SLE-7101)
+- 4.2.7
+
+-------------------------------------------------------------------
 Wed Aug 28 13:06:58 CEST 2019 - schubi@suse.de
 
 - Removed empty entry in desktop file (bsc#144894).

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -14,6 +14,9 @@
 #	Lukas Ocilka <locilka@suse.cz>
 #
 #
+
+require "y2packager/medium_type"
+
 module Yast
   module AddOnAddOnWorkflowInclude
     include Yast::Logger
@@ -27,10 +30,12 @@ module Yast
       Yast.import "AddOnProduct"
       Yast.import "WorkflowManager"
       Yast.import "Linuxrc"
+      Yast.import "InstURL"
       Yast.import "Mode"
       Yast.import "Popup"
       Yast.import "Report"
       Yast.import "Sequencer"
+      Yast.import "SourceDialogs"
       Yast.import "SourceManager"
       Yast.import "PackageSystem"
       Yast.import "ProductProfile"
@@ -109,6 +114,12 @@ module Yast
     def MediaSelect
       aliases = {
         "type"  => lambda do
+          if AddOnProduct.add_on_products.empty? && Y2Packager::MediumType.offline?
+            # preselect the installation repository without asking the user
+            # for the URL when adding an add-on first time on the offline medium
+            SourceDialogs.SetURL(InstURL.installInf2Url(""))
+            return :finish
+          end
           # use the preselected type or the same type as for the previous add-on,
           # if not set it will use the default (the code actually runs
           # SourceDialogs.SetURL(SourceDialogs.GetURL) internally)


### PR DESCRIPTION
- When installing from the offline medium we should directly offer the modules and extensions available on the installation medium.
- 4.2.7

## Screenshots

This URL/repository type selection dialog is skipped:

![addons_selection](https://user-images.githubusercontent.com/907998/65860262-382ca800-e36a-11e9-8bf0-3caf70d0d2e0.png)

And directly the modules and extensions from the installation medium are displayed:

![offline_addon_list](https://user-images.githubusercontent.com/907998/65860534-cacd4700-e36a-11e9-9036-c4bf5075671c.png)

Which is more straight forward and easier for user.