### PR TITLE
Display the human readable product names (bsc#1153663)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 11 08:30:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Display the human readable product names in the summary dialog
+  (bsc#1153663)
+- 4.2.8
+
+-------------------------------------------------------------------
 Mon Sep 30 07:50:24 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Automatically offer the modules and extensions in the offline

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -16,6 +16,7 @@
 #
 
 require "y2packager/medium_type"
+require "y2packager/resolvable"
 
 module Yast
   module AddOnAddOnWorkflowInclude
@@ -801,12 +802,7 @@ module Yast
         )
         Item(
           Id(index),
-          Ops.get_string(
-            # sformat (_("Product %1"), product["product"]:"")
-            product,
-            "product",
-            ""
-          ),
+          product_label(product["product"]),
           media
         )
       end
@@ -1923,6 +1919,19 @@ module Yast
       ret = :skip if ret == :next && SourceDialogs.addon_enabled == false
       log.debug "TypeDialog result: #{ret}"
       ret
+    end
+
+  private
+
+    # Find the human readable product name for the product ID
+    # @param product [String] the product name (ID)
+    # @return [String] a human readable product name or the original ID if not found
+    def product_label(product)
+      selected_product = Y2Packager::Resolvable.find(
+        kind: :product, status: :selected, name: product).first
+
+      # fallback to the internal product name
+      selected_product&.display_name || product
     end
   end
 end


### PR DESCRIPTION
- Display the human readable product names instead of the internal identifiers in the add-on products summary table
- https://bugzilla.suse.com/show_bug.cgi?id=1153663
- 4.2.8

### Original

![addon_names_orig](https://user-images.githubusercontent.com/907998/66637002-85363700-ec12-11e9-9bbe-4f80f04d961f.png)


### Fixed

![addon_names_fixed](https://user-images.githubusercontent.com/907998/66637019-8d8e7200-ec12-11e9-8a7e-b337d3aedc35.png)
