### PR TITLE
Decreasing required memory

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 31 17:18:34 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650).
+- 4.2.9
+
+-------------------------------------------------------------------
 Fri Oct 11 08:30:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Display the human readable product names in the summary dialog

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -2,7 +2,8 @@
 Thu Oct 31 17:18:34 CET 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
-  in order to decrease the required memory (bsc#1132650).
+  in order to decrease the required memory (bsc#1132650,
+  bsc#1140037).
 - 4.2.9
 
 -------------------------------------------------------------------

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/clients/vendor.rb
+++ b/src/clients/vendor.rb
@@ -105,8 +105,7 @@ module Yast
         @base = deep_copy(@products) if Builtins.size(@base) == 0
         @product = @base[0]
         if @product
-          @version = @product.version || ""
-          @version = Ops.get(Builtins.splitstring(@version, "-"), 0, "") # split off release
+          @version = @product.version_version
         end
 
         Builtins.y2milestone("Trying %1", @cdpath)

--- a/src/clients/vendor.rb
+++ b/src/clients/vendor.rb
@@ -98,18 +98,16 @@ module Yast
       else
         Pkg.TargetInit("/", false)
 
-        @products = Pkg.ResolvableProperties("", :product, "")
+        @products = Y2Packager::Resolvable.find(kind: :product,
+           status:    :installed,
+           category:  "base")
         @products = [] if @products == nil
-        @products = Builtins.filter(@products) do |p|
-          Ops.get(p, "status") == :installed
-        end
-        @base = Builtins.filter(@products) do |p|
-          Ops.get_string(p, "category", "") == "base"
-        end
         @base = deep_copy(@products) if Builtins.size(@base) == 0
-        @product = Ops.get(@base, 0, {})
-        @version = Ops.get_string(@product, "version", "")
-        @version = Ops.get(Builtins.splitstring(@version, "-"), 0, "") # split off release
+        @product = @base[0]
+        if @product
+          @version = @product.version || ""
+          @version = Ops.get(Builtins.splitstring(@version, "-"), 0, "") # split off release
+        end
 
         Builtins.y2milestone("Trying %1", @cdpath)
         @dirlist2 = Convert.to_list(SCR.Read(path(".target.dir"), @cdpath))

--- a/src/clients/vendor.rb
+++ b/src/clients/vendor.rb
@@ -104,9 +104,7 @@ module Yast
         @products = [] if @products == nil
         @base = deep_copy(@products) if Builtins.size(@base) == 0
         @product = @base[0]
-        if @product
-          @version = @product.version_version
-        end
+        @version = @product ? @product.version_version : ""
 
         Builtins.y2milestone("Trying %1", @cdpath)
         @dirlist2 = Convert.to_list(SCR.Read(path(".target.dir"), @cdpath))

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1451,12 +1451,8 @@ module Yast
       log.info("Currently used add-ons: #{product_infos}")
 
       products = product_infos.map do |index, product_desc|
-        product_name = [ product_desc["product"].display_name,
-          product_desc["product"].name,
-          _("Unknown product") ].reject(&:empty?).first
-
         Item(Id("product_#{index}"),
-          product_name,
+          ui_product_name(product_desc["product"]),
           product_desc["info"]["URLs"].first || _("Unknown URL")
         )
       end
@@ -1497,10 +1493,7 @@ module Yast
         return nil
       end
 
-      product_name = [ pi["product"].display_name,
-        pi["product"].name,
-        _("Unknown product") ].reject(&:empty?).first
-
+      product_name = ui_product_name(pi["product"])
       if !Popup.AnyQuestion(
           Label.WarningMsg,
           Builtins.sformat(
@@ -1913,6 +1906,14 @@ module Yast
     end
 
   private
+
+    # Find the human readable product name from the product
+    # @param [Y2Packager::Resolvable] the product
+    # @return [String] a human readable product name
+    def ui_product_name(product)
+      return _("Unknown product") unless product
+      [product.display_name, product.name, _("Unknown product")].reject(&:empty?).first
+    end
 
     # Find the human readable product name for the product ID
     # @param product [String] the product name (ID)

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1188,15 +1188,17 @@ module Yast
         return
       end
 
+      vendor = pi["product"].vendor.empty? ? _("Unknown vendor") : pi["product"].vendor
+      version = pi["product"].version.empty? ? _("Unknown version") : pi["product"].version
       rt_description = Builtins.sformat(
         "<p>%1\n%2\n%3\n%4</p>",
         Builtins.sformat(
           _("<b>Vendor:</b> %1<br>"),
-          (pi["product"].vendor || _("Unknown vendor"))
+          vendor
         ),
         Builtins.sformat(
           _("<b>Version:</b> %1<br>"),
-          (pi["product"].version || _("Unknown version"))
+          version
         ),
         Builtins.sformat(
           _("<b>Repository URL:</b> %1<br>"),
@@ -1334,10 +1336,10 @@ module Yast
 
       Builtins.foreach(installed_products) do |one_product|
         # only add-on products should be listed
-        if (one_product.type || "addon") != "addon"
+        if one_product.type != "addon"
           Builtins.y2milestone(
             "Skipping product: %1",
-            one_product.display_name || one_product.name
+            one_product.display_name.empty? ? one_product.name : one_product.display_name
           )
           next
         end
@@ -1544,7 +1546,7 @@ module Yast
         # Package is not at the repositories to be deleted
         if !Builtins.contains(
             src_ids,
-            (one_package.source || -1)
+            one_package.source
           )
           next false
         end

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -376,9 +376,9 @@ module Yast
     def ProductSelect
       # Do not use Y2Packager::Resolvable.find(kind: :product) because the
       # returned Resolvables have not the variable "media".
-      # It ist not so important because this function will be called in an
+      # It is not so important because this function will be called in an
       # installed system with the command "/sbin/yast2 add-on URL" only
-      all_products = Y2Packager::Resolvable.find(kind: :product)
+      all_products = Pkg.ResolvableProperties("", :product, "")
 
       already_used_urls = {}
       # getting all source urls and product_dirs
@@ -1345,7 +1345,7 @@ module Yast
         counter = Ops.add(counter, 1)
         Builtins.y2milestone(
           "Product: %1, Info: %2",
-          one_product,
+          one_product.name,
           repository_info
         )
         if repository_info == nil

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -360,7 +360,7 @@ module Yast
         next unless @added_repos.include?(product.source)
         # Product is not available (either `installed or `selected or ...)
         if product.status != :available
-          log.info("Skipping product #{product.name.inspect} with status " \
+          log.info("Skipping product #{product.name} with status " \
             "#{product.status}")
           next
         end
@@ -628,7 +628,7 @@ module Yast
           Builtins.foreach(prods) do |prod|
             product_found = false
             Builtins.foreach(all_products) do |p|
-               if Ops.get_string(p, "name", "") ==
+              if Ops.get_string(p, "name", "") ==
                   Ops.get_string(prod, "name", "") &&
                   Ops.get_string(p, "version", "") ==
                     Ops.get_string(prod, "version", "") &&

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1450,9 +1450,10 @@ module Yast
       log.info("Currently used add-ons: #{product_infos}")
 
       products = product_infos.map do |index, product_desc|
-        product_name = product_desc["product"].display_name
-        product_name = product_desc["product"].name if product_name.empty?
-        product_name = _("Unknown product") if product_name.empty?
+        product_name = [ product_desc["product"].display_name,
+          product_desc["product"].name,
+          _("Unknown product") ].reject(&:empty?).first
+
         Item(Id("product_#{index}"),
           product_name,
           product_desc["info"]["URLs"].first || _("Unknown URL")
@@ -1495,9 +1496,9 @@ module Yast
         return nil
       end
 
-      product_name = pi["product"].display_name
-      product_name = pi["product"].name if product_name.empty?
-      product_name = _("Unknown product") if product_name.empty?
+      product_name = [ pi["product"].display_name,
+        pi["product"].name,
+        _("Unknown product") ].reject(&:empty?).first
 
       if !Popup.AnyQuestion(
           Label.WarningMsg,

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1571,7 +1571,7 @@ module Yast
       # Removing selected product, whatever it means
       # It might remove several products when they use the same name
       if (pi["product"].status == :installed ||
-          pi["product"].status == :selected &&
+          pi["product"].status == :selected) &&
           pi["product"].name != ""
         Builtins.y2milestone(
           "Removing product: '%1'",

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -75,13 +75,14 @@ describe "Yast::AddOnWorkflowInclude" do
       end
 
       it "returns :next" do
-        allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([])
+        allow(Y2Packager::Resolvable).to receive(:find).and_return([])
         allow(Yast::Pkg).to receive(:ResolvableInstall)
         expect(AddonIncludeTester.InstallProduct).to eq(:next)
       end
 
       it "selects the available products from the added repositories" do
-        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return([p1, p2])
+        expect(Y2Packager::Resolvable).to receive(:find).and_return(
+          [Y2Packager::Resolvable.new(p1), Y2Packager::Resolvable.new(p2)])
         expect(Yast::Pkg).to receive(:ResolvableInstall).with("product1", :product)
         expect(Yast::Pkg).to receive(:ResolvableInstall).with("product2", :product)
 
@@ -89,16 +90,17 @@ describe "Yast::AddOnWorkflowInclude" do
       end
 
       it "ignores the products from other repositories" do
-        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(
-          [p1.merge("source" => 1), p2.merge("source" => 2)])
+        expect(Y2Packager::Resolvable).to receive(:find).and_return(
+          [Y2Packager::Resolvable.new(p1.merge("source" => 1)), Y2Packager::Resolvable.new(p2.merge("source" => 2))])
         expect(Yast::Pkg).to_not receive(:ResolvableInstall)
 
         AddonIncludeTester.InstallProduct
       end
 
       it "ignores the already selected repositories" do
-        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(
-          [p1.merge("status" => :selected), p2.merge("status" => :selected)])
+        expect(Y2Packager::Resolvable).to receive(:find).and_return(
+          [Y2Packager::Resolvable.new(p1.merge("status" => :selected)),
+           Y2Packager::Resolvable.new(p2.merge("status" => :selected))])
         expect(Yast::Pkg).to_not receive(:ResolvableInstall)
 
         AddonIncludeTester.InstallProduct


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.