### PR TITLE
[SLE-15-SP2] Fix the sub-workflow user input handling

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 21 12:36:10 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Handle correctly the user input when going back (bsc#1156528)
+- 4.2.9
+
+-------------------------------------------------------------------
 Fri Oct 11 08:30:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Display the human readable product names in the summary dialog

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1016,9 +1016,10 @@ module Yast
           Pkg.SourceReleaseAll
 
           Wizard.SetTitleIcon("yast-addon")
+
           ret2 = RunWizard()
 
-          break if ret2 == :back
+          ret = ret2 if ret2 == :back
           return :abort if ret2 == :abort
 
           log.info "Subworkflow result: ret2: #{ret2}"


### PR DESCRIPTION
### :memo: The same than #89, for `SLE-15-SP2`

## Problem

> the installer does not go back beyond the "Add On Product" step

* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1156528
* Trello: https://trello.com/c/tOe99fFW/1457-sles15-sp2-p2-1156528-the-installer-does-not-go-back-beyond-the-add-on-product-step

## Reason

Changes made in https://github.com/yast/yast-add-on/pull/78 (and https://github.com/yast/yast-add-on/pull/79)  to not abort the installation when an EULA add-on is refused [_breaks_](https://github.com/yast/yast-add-on/blob/fbb1c47d36269ebcc8f9eca988b93c102e6b41bb/src/include/add-on/add-on-workflow.rb#L1030) the sub-workflow without propagating the action first when the user is going _:back_.

## Solution

Propagate the user input properly, without forcing to break the workflow. Actually, it [is already being interrupted](https://github.com/yast/yast-add-on/blob/fbb1c47d36269ebcc8f9eca988b93c102e6b41bb/src/include/add-on/add-on-workflow.rb#L1078) when the action is :back (among others).

## Notes

I was also tempted to improve a little bit the code changing the `if` statement by a `case` one, which would allow to include the `ret = ret2` assignation when the `ret2 == :back`, reducing the complexity (a little bit).

But I discarded the idea since it's out of the scope of this fix.


## Test

Tested manually via dud.

## Screencast

<details>
<summary>Click to show/hide a short screencast</summary>

<hr/>

![](https://user-images.githubusercontent.com/1691872/69355675-1a006b80-0c7a-11ea-8c6d-a836b683aa8f.gif)

</details>


