### PR TITLE
Fixed crash when cloning the system (bsc#1158247)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec  3 09:40:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed crash when cloning the system (bsc#1158247)
+- 4.2.11
+
+-------------------------------------------------------------------
 Thu Nov 21 13:36:10 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1302,17 +1302,7 @@ module Yast
     end
 
     def GetAllProductsInfo
-      all_products = Y2Packager::Resolvable.find(:product)
-
-      all_products = Builtins.maplist(all_products) do |one_product|
-        # otherwise it fills the log too much
-        one_product.license = one_product.license[0..40] + "..."
-        one_product.description = one_product.description[0..40] + "..."
-
-        deep_copy(one_product)
-      end
-
-      deep_copy(all_products)
+      Y2Packager::Resolvable.find(kind: :product)
     end
 
     def GetInstalledProducts


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1158247
- Fixed reading the products, `Y2Packager::Resolvable.find` expects a `Hash` parameter
- Some additional cleanup
  - We do not need the shorten the license text, the new `Y2Packager::Resolvable` objects do not load the license text by default, the license is lazy loaded after calling the `.license` method
  - Removed that useless `deep_copy` and `Builtins.maplist` calls
- Tested manually, cloning now does not crash
- 4.2.11