### PR TITLE
Improved adding add-ons on the Full medium (jsc#SLE-7101)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  5 08:40:08 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not offer add-ons on the Full medium when the system is
+  registered (jsc#SLE-7101)
+- 4.2.12
+
+-------------------------------------------------------------------
 Tue Dec  3 09:40:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed crash when cloning the system (bsc#1158247)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/test/add-on-workflow_test.rb
+++ b/test/add-on-workflow_test.rb
@@ -1,0 +1,66 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+require_relative "../src/include/add-on/add-on-workflow.rb"
+
+# just a dummy class for including the tested methods
+class AddOnAddOnWorkflowIncludeTest
+  include Yast::AddOnAddOnWorkflowInclude
+end
+
+describe Yast::AddOnAddOnWorkflowInclude do
+  subject { AddOnAddOnWorkflowIncludeTest.new }
+
+  describe ".media_type_selection" do
+    context "Full medium installation with no add-ons yet" do
+      let(:registration) { double("Registration::Registration", is_registered?: registered?) }
+
+      before do
+        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return([])
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Y2Packager::MediumType).to receive(:offline?).and_return(true)
+        allow(Yast::InstURL).to receive(:installInf2Url)
+        allow(Yast::SourceDialogs).to receive(:SetURL)
+
+        allow(Yast::SourceDialogs).to receive(:GetURL)
+        allow(Yast::SourceDialogs).to receive(:addon_enabled)
+        allow(subject).to receive(:TypeDialogOpts)
+
+        stub_const("Registration::Registration", registration)
+        allow(subject).to receive(:require).with("registration/registration")
+      end
+
+      context "not registered" do
+        let(:registered?) { false }
+
+        it "preselects the installation URL for the add-ons" do
+          expect(Yast::InstURL).to receive(:installInf2Url)
+          expect(Yast::SourceDialogs).to receive(:SetURL)
+          subject.media_type_selection
+        end
+  
+        it "returns the :finish symbol" do
+          expect(subject.media_type_selection).to eq(:finish)
+          subject.media_type_selection
+
+        end
+      end
+      
+      context "registered" do
+        let(:registered?) { true }
+
+        it "does not preselect the installation URL for the add-ons" do
+          expect(Yast::InstURL).to_not receive(:installInf2Url)
+          expect(Yast::SourceDialogs).to_not receive(:SetURL)
+          subject.media_type_selection
+        end
+  
+        it "returns the user input" do
+          allow(subject).to receive(:TypeDialogOpts).and_return(:next)
+          expect(subject.media_type_selection).to eq(:next)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The recent changes enable optional registration also on the Full medium. But we need to avoid mixing the add-ons from SCC (or RMT) with the add-ons from the Full DVD medium. We need to skip the automatic add-ons selection from the medium when the system is registered. 

## Fix

If the system is registered skip that automatically displayed add-on dialog.

- 4.2.12