### PR TITLE
allow optional string and map types

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  7 08:58:18 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Autoyast schema: Allow optional types for string and map objects
+  (bsc#1170886)
+- 4.3.0
+
+-------------------------------------------------------------------
 Tue Jan 28 09:30:52 CET 2020 - schubi@suse.de
 
 - Fix in installation workflow: Can go back from

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.15
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/add-on.rnc
+++ b/src/autoyast-rnc/add-on.rnc
@@ -2,6 +2,8 @@ default namespace = "http://www.suse.com/1.0/yast2ns"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
+include "common.rnc"
+
 add-on =
   element add-on {
       MAP,

--- a/src/autoyast-rnc/add-on.rnc
+++ b/src/autoyast-rnc/add-on.rnc
@@ -4,51 +4,69 @@ namespace config = "http://www.suse.com/1.0/configns"
 
 add-on =
   element add-on {
-      add_on_products* &
-      add_on_others*
+      MAP,
+      (
+        add_on_products* &
+        add_on_others*
+      )
   }
 listentry =
   element listentry {
-     media_url & # here it is mandatory
-     product? &
-     name? &
-     alias? &
-     product_dir? &
-     ask_on_error? &
-     confirm_license? &
-     priority? &
-     element signature-handling {
-        element accept_unsigned_file { BOOLEAN }? &
-        element accept_file_without_checksum { BOOLEAN }? &
-        element accept_verification_failed { BOOLEAN }? &
-        element accept_unknown_gpg_key {
-            element all { BOOLEAN }? &
-            element keys {
-                LIST,
-                element keyid { text }*
+     MAP,
+     (
+       media_url & # here it is mandatory
+       product? &
+       name? &
+       alias? &
+       product_dir? &
+       ask_on_error? &
+       confirm_license? &
+       priority? &
+       element signature-handling {
+          MAP,
+          (
+            element accept_unsigned_file { BOOLEAN }? &
+            element accept_file_without_checksum { BOOLEAN }? &
+            element accept_verification_failed { BOOLEAN }? &
+            element accept_unknown_gpg_key {
+                MAP,
+                (
+                  element all { BOOLEAN }? &
+                  element keys {
+                      LIST,
+                      element keyid { STRING }*
+                  }?
+                )
+            }? &
+            element accept_non_trusted_gpg_key {
+                MAP,
+                (
+                  element all { BOOLEAN }? &
+                  element keys {
+                      LIST,
+                      element keyid { STRING }*
+                  }?
+                )
+            }? &
+            element import_gpg_key {
+                MAP,
+                (
+                  element all { BOOLEAN }? &
+                  element keys {
+                      LIST,
+                      element keyid { STRING }*
+                  }?
+                )
             }?
-        }? &
-        element accept_non_trusted_gpg_key {
-            element all { BOOLEAN }? &
-            element keys {
-                LIST,
-                element keyid { text }*
-            }?
-        }? &
-        element import_gpg_key {
-            element all { BOOLEAN }? &
-            element keys {
-                LIST,
-                element keyid { text }*
-            }?
-        }?
-     }?
+          )
+       }?
+     )
   }
-media_url = element media_url { text }
-product = element product { text }
-name = element name { text }
-alias = element alias { text }
-product_dir = element product_dir { text }
+media_url = element media_url { STRING }
+product = element product { STRING }
+name = element name { STRING }
+alias = element alias { STRING }
+product_dir = element product_dir { STRING }
 ask_on_error = element ask_on_error { BOOLEAN }
 confirm_license = element confirm_license { BOOLEAN }
 priority = element priority { INTEGER }
@@ -73,4 +91,4 @@ add_on_others =
   element add_on_others {
      attribute config:type { text }?,
      listentry*
-  }  
+  }


### PR DESCRIPTION
trello: https://trello.com/c/HkFkUQHj/1791-3-continue-with-new-xml-parser-xml-validation

depends on yast/yast-autoinstallation#598

Agreed to postpone for now that trang and jing travis validation to not delay even more new xml parser.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1170886