### PR TITLE
Do not export registered add-ons

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 16 10:17:01 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export registered add-ons, as they should be included
+  in the <suse_register/> section of the profile (bsc#1174202).
+- 4.3.2
+
+-------------------------------------------------------------------
 Wed Jun 10 14:04:00 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Reduce autoyast profile size if addons are empty (bsc#1172749) 

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -58,18 +58,65 @@ module Yast
     #        </add_on_others>
     #      </add-on>
     def Export
-      others = @add_on_others.map do |p|
-        { "media_url"   => p["url"],
-          "alias"       => p["alias"],
-          "priority"    => p["priority"],
-          "name"        => p["name"],
-          "product_dir" => p["product_dir"] }
+      others = @add_on_others.each_with_object([]) do |addon, all|
+        next if registered_addon?(addon)
+
+        all << {
+          "media_url"   => addon["url"],
+          "alias"       => addon["alias"],
+          "priority"    => addon["priority"],
+          "name"        => addon["name"],
+          "product_dir" => addon["product_dir"]
+        }
       end
       { "add_on_others" => others }
     end
 
     publish function: :Export, type: "map ()"
     publish function: :Read, type: "map()"
+
+  private
+
+    # Determine whether an addon corresponds to a registered product
+    #
+    # @param addon [Hash] Addon data
+    # @return [Boolean]
+    def registered_addon?(addon)
+      return false unless addon["url"]
+
+      url = normalize_url(addon["url"])
+      registered_repositories_urls.include?(url)
+    end
+
+    # Returns the URLs corresponding to registered products repositories
+    #
+    # @return [Array<URI>]
+    def registered_repositories_urls
+      return @registered_repositories_urls if @registered_repositories_urls
+
+      begin
+        require "suse/connect"
+      rescue LoadError
+        []
+      end
+      status = SUSE::Connect::YaST.status({})
+      repositories = status.activated_products.map(&:repositories).flatten
+      @registered_repositories_urls = repositories.map { |r| normalize_url(r["url"]) }
+    end
+
+    # Normalizes the URL to make the comparison easier
+    #
+    # It removes the query, the fragment and the trailing '/' character is found.
+    #
+    # @param url [URI,String] URL to normalize
+    # @return [URI]
+    def normalize_url(url)
+      uri = URI(url)
+      uri.fragment = nil
+      uri.query = nil
+      uri.path = uri.path.delete_suffix("/")
+      uri
+    end
   end
 
   AddOnOthers = AddOnOthersClass.new

--- a/src/modules/AddOnOthers.rb
+++ b/src/modules/AddOnOthers.rb
@@ -95,12 +95,12 @@ module Yast
       return @registered_repositories_urls if @registered_repositories_urls
 
       begin
-        require "suse/connect"
+        require "registration/registration"
       rescue LoadError
-        []
+        return []
       end
-      status = SUSE::Connect::YaST.status({})
-      repositories = status.activated_products.map(&:repositories).flatten
+      activated_products = Registration::Registration.new.activated_products
+      repositories = activated_products.map(&:repositories).flatten
       @registered_repositories_urls = repositories.map { |r| normalize_url(r["url"]) }
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/jzih5O43/1928-8-export-registered-add-ons-properly
Related to: https://github.com/yast/yast-registration/pull/502

Do not export those add-ons that have been registered. They should be listed in the `<suse_register/>` section of the profile. This code has been manually tested but it is still a WIP.