### PR TITLE
Fix add-on section schema

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 14:05:54 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the schema definition for the add_on_products
+  and add_on_others elements (boo#1174424).
+- 4.3.3
+
+-------------------------------------------------------------------
 Thu Jul 16 10:17:01 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export registered add-ons, as they should be included

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/add-on.rnc
+++ b/src/autoyast-rnc/add-on.rnc
@@ -78,7 +78,7 @@ priority = element priority { INTEGER }
 #
 add_on_products =
   element add_on_products {
-     attribute config:type { text }?,
+     LIST,
      listentry*
   }
 #
@@ -91,6 +91,6 @@ add_on_products =
 #
 add_on_others =
   element add_on_others {
-     attribute config:type { text }?,
+     LIST,
      listentry*
   }


### PR DESCRIPTION
Allows to use the new `type` and `t` attributes to specify the type of the `add_on_products` and `add_on_others` sections.

Trello: https://trello.com/c/WtDObsGz/1983-3-tw-1174424-build-20200720-autoyast-profile-doesnt-validate
Bug report: https://bugzilla.opensuse.org/show_bug.cgi?id=1174424