### PR TITLE
Fixed regression in the add-on repository names (bsc#1175374)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  3 07:11:47 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed regression in the add-on repository names in AutoYaST
+  installation (bsc#1175374, related to bsc#1172477)
+- 4.2.16
+
+-------------------------------------------------------------------
 Tue Jan 28 09:30:52 CET 2020 - schubi@suse.de
 
 - Fix in installation workflow: Can go back from

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only
@@ -41,6 +41,8 @@ Requires:       yast2-country
 Requires:       yast2-installation
 # Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
 Requires:       yast2-packager >= 4.2.16
+# "raw_name" in Pkg.SourceEditGet/Set()
+Requires:       yast2-pkg-bindings >= 4.2.8
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Obsoletes:      yast2-add-on-devel-doc

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -309,10 +309,10 @@ module Yast
 
       return if repo.nil?
 
-      repo["name"] = preferred_name_for(add_on, repo)
+      repo["raw_name"] = preferred_name_for(add_on, repo)
       repo["priority"] = add_on["priority"] if add_on.key?("priority")
 
-      log.info("Preferred name: #{repo["name"]}")
+      log.info("Preferred name: #{repo["raw_name"]}")
 
       Pkg.SourceEditSet(sources)
     end
@@ -344,7 +344,7 @@ module Yast
       found_repo = repos_at_url.find { |r| r[1] == product_dir }
       return found_repo[0] if found_repo
 
-      repo["name"]
+      repo["raw_name"]
     end
 
     # Installs given product

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -326,7 +326,7 @@ module Yast
     #   * name of given repo
     #
     # @param [Hash] addon
-    # @param [Array] repo
+    # @param [Hash] repo
     #
     # @return [String] preferred name for add-on/repo
     def preferred_name_for(add_on, repo)

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -285,7 +285,8 @@ describe Yast::AddOnAutoClient do
             "autorefresh"  => true,
             "enabled"      => true,
             "keeppackaged" => false,
-            "name"         => "Updated repo",
+            "name"         => "repo_to_be_updated",
+            "raw_name"     => "Updated repo",
             "priority"     => 20,
             "service"      => ""
           },


### PR DESCRIPTION
## The Problem

- This is similar fix to https://github.com/yast/yast-packager/pull/533, see that PR for more details
- I do not know when exactly this bug happens and what's the real problem, I found the problematic place by grepping for `Pkg.SourceEditSet`

## Testing

- As metioned above, I could not easily test the bug fix (and it's AutoYaST...)
- But there is an unit test for that so hopefully that's enough
- Either it fixes the problem or we get a bug report with more details later
