### PR TITLE
Display the add-on selection dialog even when a DUD add-on is present

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 17 07:49:04 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not skip the Full medium add-on selection when a driver update
+  disk (DUD) is used (bsc#1174562)
+- 4.2.17
+
+-------------------------------------------------------------------
 Thu Sep  3 07:11:47 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed regression in the add-on repository names in AutoYaST

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -130,4 +130,46 @@ describe "Yast::AddOnWorkflowInclude" do
       AddonIncludeTester.RunAddProductWorkflow
     end
   end
+
+  describe "#RunAddOnMainDialog" do
+    before do
+      allow(Yast::Pkg).to receive(:SourceReleaseAll)
+      allow(Yast::Stage).to receive(:initial).and_return(true)
+      allow(AddonIncludeTester).to receive(:HasInsufficientMemory).and_return(false)
+      allow(Yast::WorkflowManager).to receive(:SetBaseWorkflow)
+      allow(Yast::Wizard).to receive(:SetTitleIcon)
+      allow(AddonIncludeTester).to receive(:Redraw)
+      allow(Yast::AddOnProduct).to receive(:PrepareForRegistration)
+      allow(Yast::AddOnProduct).to receive(:Integrate)
+      allow(Yast::AddOnProduct).to receive(:ProcessRegistration)
+      allow(Yast::AddOnProduct).to receive(:ReIntegrateFromScratch)
+      allow(Yast::Wizard).to receive(:RestoreBackButton)
+      allow(Yast::Wizard).to receive(:RestoreAbortButton)
+      allow(Yast::Wizard).to receive(:RestoreNextButton)
+      allow(Yast::UI).to receive(:UserInput).and_return(:next)
+    end
+
+    context "a DUD add-on present, using Full medium" do
+      before do
+        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return([
+          {
+            "media" => 4,
+            "product" => "Driver Update 0",
+            "autoyast_product" => "Driver Update 0",
+            "media_url" => "dir:///update/000/repo?alias=DriverUpdate0",
+            "product_dir" => "",
+            "priority" => 50
+          }
+        ])
+        allow(Y2Packager::MediumType).to receive(:offline?).and_return(true)
+      end
+
+      it "asks for the media addons and stores the state" do
+        expect(AddonIncludeTester).to receive(:RunWizard).and_return(:next)
+        expect { AddonIncludeTester.RunAddOnMainDialog(true, true, true, "", "", "", true) }.to \
+          change { Yast::AddOnAddOnWorkflowInclude.class_variable_get(:@@media_addons_selected) } \
+          .from(false).to(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- YaST skipped the add-on selection on the Full medium when an add-on was already present to avoid asking user several times when going back and forth.
- But when a DUD is used it also contains an add-on internally and then the dialog was skipped.
- The solution is to store a flag that the dialog has been already displayed, do not check the current add-ons as we cannot detect which come from the Full medium.
- See https://bugzilla.suse.com/show_bug.cgi?id=1174562

## Screenshots

### Before

Originally the add-on selection dialog was skipped, after skipping the registration the add-on overview was displayed showing only the DUD add-on.

![addon_dud_broken](https://user-images.githubusercontent.com/907998/92693609-214a5000-f346-11ea-8131-31cf9e0595bf.png)

### After

With the fix the add-on selection from the Full medium is displayed and later the selected add-ons are visible in the table.

![addon_dud_fixed1](https://user-images.githubusercontent.com/907998/92693748-5060c180-f346-11ea-8fe1-0fbef4fe51c1.png)
![addon_dud_fixed2](https://user-images.githubusercontent.com/907998/92693755-53f44880-f346-11ea-9d9a-2d711c82a146.png)


## TODO

- [x] Wait for merging https://github.com/yast/yast-add-on/pull/102
- [ ] Release it together as one update