### PR TITLE
Remove SuSEFirewall2 references

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 30 10:49:56 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not import SuSEFirewall2 anymore as the support was dropped
+  from YaST (fate#323460)
+- 4.3.7
+
+-------------------------------------------------------------------
 Thu Sep 17 13:06:05 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not skip the Full medium add-on selection when a driver update

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -41,7 +41,6 @@ module Yast
       Yast.import "SourceManager"
       Yast.import "PackageSystem"
       Yast.import "ProductProfile"
-      Yast.import "SuSEFirewall"
       Yast.import "Stage"
       Yast.import "Wizard"
       Yast.import "Confirm"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,9 +18,6 @@ end
 # Stub classes from other modules to speed up a build
 stub_module("AutoinstGeneral")
 stub_module("AutoinstSoftware")
-# the SuSEFirewall module checks the firewall status in the constructor,
-# avoid displaying a PolicyKit popup asking for the root password...
-stub_module("SuSEFirewall")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
## Problem

Since SLE-15, firewalld is the default firewall and the YaST configuration of SuSEFirewall2 has been dropped but we are still trying to import it

- see https://github.com/yast/yast-yast2/pull/806

## Solution

Drop SuSEFirewall2 references.

