### PR TITLE
Adapt unit test to recent changes in Yast::Report

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 14:42:44 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.8
+
+-------------------------------------------------------------------
 Wed Sep 30 10:49:56 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not import SuSEFirewall2 anymore as the support was dropped

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -345,20 +345,24 @@ describe Yast::AddOnAutoClient do
           let(:ask_on_error) { true }
 
           it "ask to make it available" do
-            expect(Yast::Popup).to receive(:ContinueCancel)
+            expect(Yast::Popup).to receive(:ContinueCancel).and_return false
+
+            # We are returning false on the ContinueCancel mock, so we decide to
+            # stop retrying and the error is finally displayed
+            allow(Yast::Report).to receive(:Error)
 
             subject.write
           end
         end
 
         context "ask_on_error=false" do
-          before do
-            allow(Yast::Popup).to receive(:ContinueCancel).and_return(false)
-          end
-
           let(:ask_on_error) { false }
 
-          it "report error" do
+          it "does not ask to make it available" do
+            expect(Yast::Popup).to_not receive(:ContinueCancel)
+          end
+
+          it "reports the error" do
             expect(Yast::Report).to receive(:Error)
 
             subject.write


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-autoinstallation, yast-add-on, yast-bootloader, yast-configuration-management, yast-dns-server, yast-installation, yast-kdump, yast-network, yast-nfs-client, yast-ntp-client, yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager, yast-samba-server, yast-packager, yast-registration and yast-sysconfig.

This should fix the problem for this repository.