### PR TITLE
Improve UX using generic error message for unknown repo URL

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 19 16:00:54 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Improve UX by using a less misleading message when
+  repo URL is unknown (bsc#1188635).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 12:55:53 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1431,9 +1431,11 @@ module Yast
       log.info("Currently used add-ons: #{product_infos}")
 
       products = product_infos.map do |index, product_desc|
-        Item(Id("product_#{index}"),
+        Item(
+          Id("product_#{index}"),
           ui_product_name(product_desc["product"]),
-          product_desc["info"]["URLs"].first || _("Unknown URL"))
+          product_desc["info"]["URLs"].first || _("Not found in enabled repositories")
+        )
       end
 
       UI.ChangeWidget(Id("list_of_addons"), :Items, products)

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1411,10 +1411,13 @@ module Yast
       log.info("Currently used add-ons: #{product_infos}")
 
       products = product_infos.map do |index, product_desc|
+        # TRANSLATORS: Product status, the installed product was not found in any enabled repository
+        url = product_desc["info"]["URLs"].first || _("Not found in enabled repositories")
+
         Item(
           Id("product_#{index}"),
           ui_product_name(product_desc["product"]),
-          product_desc["info"]["URLs"].first || _("Not found in enabled repositories")
+          url
         )
       end
 

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1189,17 +1189,17 @@ module Yast
           _("<b>Version:</b> %1<br>"),
           version
         ),
-        Builtins.sformat(
-          _("<b>Repository URL:</b> %1<br>"),
-          if Ops.greater_than(
-            Builtins.size(Ops.get_list(pi, ["info", "URLs"], [])),
-            0
+        if Ops.greater_than(
+          Builtins.size(Ops.get_list(pi, ["info", "URLs"], [])),
+          0
+        )
+          Builtins.sformat(
+            _("<b>Repository URL:</b> %1<br>"),
+              Builtins.mergestring(Ops.get_list(pi, ["info", "URLs"], []), ",")
           )
-            Builtins.mergestring(Ops.get_list(pi, ["info", "URLs"], []), ",")
-          else
-            _("Unknown repository URL")
-          end
-        ),
+        else
+          ""
+        end,
         if Ops.greater_than(
           Builtins.size(Ops.get_list(pi, ["info", "aliases"], [])),
           0

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -1171,49 +1171,29 @@ module Yast
     end
 
     def AdjustInfoWidget
-      pi = ReturnCurrentlySelectedProductInfo()
-      if pi.nil? || pi == {}
+      product_info = ReturnCurrentlySelectedProductInfo()
+
+      if product_info.to_h.empty?
         UI.ChangeWidget(Id("product_details"), :Value, "")
+
         return
       end
 
-      vendor = pi["product"].vendor.empty? ? _("Unknown vendor") : pi["product"].vendor
-      version = pi["product"].version.empty? ? _("Unknown version") : pi["product"].version
-      rt_description = Builtins.sformat(
-        "<p>%1\n%2\n%3\n%4</p>",
-        Builtins.sformat(
-          _("<b>Vendor:</b> %1<br>"),
-          vendor
-        ),
-        Builtins.sformat(
-          _("<b>Version:</b> %1<br>"),
-          version
-        ),
-        if Ops.greater_than(
-          Builtins.size(Ops.get_list(pi, ["info", "URLs"], [])),
-          0
-        )
-          Builtins.sformat(
-            _("<b>Repository URL:</b> %1<br>"),
-              Builtins.mergestring(Ops.get_list(pi, ["info", "URLs"], []), ",")
-          )
-        else
-          ""
-        end,
-        if Ops.greater_than(
-          Builtins.size(Ops.get_list(pi, ["info", "aliases"], [])),
-          0
-        )
-          Builtins.sformat(
-            _("<b>Repository Alias:</b> %1<br>"),
-            Builtins.mergestring(Ops.get_list(pi, ["info", "aliases"], []), ",")
-          )
-        else
-          ""
-        end
-      )
+      product = product_info["product"]
+      info    = product_info["info"] || {}
 
-      UI.ChangeWidget(Id("product_details"), :Value, rt_description)
+      vendor  = product.vendor.empty?  ? _("Unknown vendor")  : product.vendor
+      version = product.version.empty? ? _("unknown version") : product.version
+      urls    = info.fetch("URLs", []).join(",")
+      aliases = info.fetch("aliases", []).join(",")
+
+      details = []
+      details << format(_("<b>Vendor:</b> %s<br>"), vendor)
+      details << format(_("<b>Version:</b> %s<br>"), version)
+      details << format(_("<b>Repository URL:</b> %s<br>"), urls) unless urls.empty?
+      details << format(_("<b>Repository Alias:</b> %s<br>"), aliases) unless aliases.empty?
+
+      UI.ChangeWidget(Id("product_details"), :Value, "<p>#{details.join("\n")}</p>")
 
       nil
     end


### PR DESCRIPTION
## Problem

When an add-on repository is disable (e.g., after finishing the installation the DVD repositories get automatically disabled), yast2 add-on shows the "Unknown URL" label as URL, which is a bit misleading.

* https://bugzilla.suse.com/show_bug.cgi?id=1188635
* https://trello.com/c/BNkRWGoz/4835-sles15-sp4-p2-1188635-addon-url-in-yast2-addon-package-enhanceable

## Solution

To use a more generic text "Not found in enabled repositories".

Additionally, 

* If the add-on is not found in enabled repositories, the `Repository URL` is not shown anymore in the details box
* the code to build the _additional_ details has been _refactored_ (just killed a bunch of `Builtins`)

## Screenshots

| Before | After |
| - | - |
| ![Text shown before](https://user-images.githubusercontent.com/1691872/130104577-838a9ca8-ad6b-4fe9-ba2d-4c28f7168ae4.png) | ![Text show after proposed changes](https://user-images.githubusercontent.com/1691872/130489853-3515156b-7ade-45bc-815b-995372a77eb0.png) |