### PR TITLE
[SLE-15-SP3] Auto client: do not crash when there is nothing to import 

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 31 11:15:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Auto client does not crash when trying to import from an
+  empty add-on section (bsc#1189154).
+- 4.3.9
+
+-------------------------------------------------------------------
 Thu Feb 18 14:42:44 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -25,6 +25,8 @@ module Yast
     end
 
     def import(data)
+      return true if data.nil?
+
       add_ons = data.fetch("add_on_products", [])
       # Add-on products have the same format as add-ons which have been
       # added manually by the user. So we can take the same workflow here.

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2018-2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "yast"
 require "installation/auto_client"
 

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -1,5 +1,24 @@
 #!/usr/bin/env rspec
 
+# Copyright (c) [2018-2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require_relative "../../test_helper"
 require "add-on/clients/add-on_auto"
 

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -6,6 +6,8 @@ require "add-on/clients/add-on_auto"
 Yast.import "Packages"
 
 describe Yast::AddOnAutoClient do
+  subject(:client) { described_class.new }
+
   describe "#import" do
     let(:params) do
       { "add_on_products" => add_on_products,
@@ -16,15 +18,15 @@ describe Yast::AddOnAutoClient do
       it "does not try to import add-on products" do
         expect(Yast::AddOnProduct).to_not receive(:Import)
 
-        subject.import(nil)
+        client.import(nil)
       end
 
       it "returns true" do
-        expect(subject.import(nil)).to eq(true)
+        expect(client.import(nil)).to eq(true)
       end
     end
 
-    context "when completly valid 'add_on_products' param is given" do
+    context "when given data only contains valid add-ons" do
       let(:add_on_products) do
         [
           {
@@ -54,11 +56,11 @@ describe Yast::AddOnAutoClient do
           "add_on_products" => add_on_products + add_on_others
         )
 
-        subject.import(params)
+        client.import(params)
       end
     end
 
-    context "when there are missed media_url values in given 'add_on_products'" do
+    context "when given data contains a not valid add-on" do
       let(:add_on_products) do
         [
           {
@@ -95,7 +97,7 @@ describe Yast::AddOnAutoClient do
       it "asks to user about reject them" do
         expect(Yast::Popup).to receive(:ContinueCancel).with(missed_media_url_error)
 
-        subject.import(params)
+        client.import(params)
       end
 
       it "rejects them if user decides to continue" do
@@ -103,7 +105,7 @@ describe Yast::AddOnAutoClient do
 
         expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => valid_add_on_products)
 
-        subject.import(params)
+        client.import(params)
       end
 
       it "returns false (does nothing) if user decides to abort" do
@@ -163,7 +165,7 @@ describe Yast::AddOnAutoClient do
     it "returns an unordered list sumarizing current add_on_product" do
       allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
 
-      expect(subject.summary).to eq(expected_output)
+      expect(client.summary).to eq(expected_output)
     end
   end
 
@@ -174,7 +176,7 @@ describe Yast::AddOnAutoClient do
       end
 
       it "returns true" do
-        expect(subject.modified?).to be_truthy
+        expect(client.modified?).to be_truthy
       end
     end
 
@@ -184,7 +186,7 @@ describe Yast::AddOnAutoClient do
       end
 
       it "returns true" do
-        expect(subject.modified?).to be_falsey
+        expect(client.modified?).to be_falsey
       end
     end
   end
@@ -193,7 +195,7 @@ describe Yast::AddOnAutoClient do
     it "sets configuration as changed" do
       allow(Yast::AddOnProduct).to receive(:modified=).with(true)
 
-      subject.modified
+      client.modified
     end
   end
 
@@ -201,7 +203,7 @@ describe Yast::AddOnAutoClient do
     it "resets configuration" do
       allow(Yast::AddOnProduct).to receive(:add_on_products=).with([])
 
-      subject.reset
+      client.reset
     end
   end
 
@@ -212,15 +214,15 @@ describe Yast::AddOnAutoClient do
     end
 
     it "runs add-on main dialog" do
-      expect(subject).to receive(:RunAddOnMainDialog)
+      expect(client).to receive(:RunAddOnMainDialog)
 
-      subject.change
+      client.change
     end
 
     it "returns chosen action" do
-      allow(subject).to receive(:RunAddOnMainDialog).and_return(:next)
+      allow(client).to receive(:RunAddOnMainDialog).and_return(:next)
 
-      expect(subject.change).to be(:next)
+      expect(client.change).to be(:next)
     end
   end
 
@@ -248,21 +250,21 @@ describe Yast::AddOnAutoClient do
       expect(Yast::AddOnProduct).to receive(:Export).and_return(add_on_products)
       expect(Yast::AddOnOthers).to receive(:Export).and_return(add_on_others)
 
-      expect(subject.export).to eq(add_on_products.merge(add_on_others))
+      expect(client.export).to eq(add_on_products.merge(add_on_others))
     end
 
     it "returns just non empty type of addons" do
       expect(Yast::AddOnProduct).to receive(:Export).and_return(add_on_products)
       expect(Yast::AddOnOthers).to receive(:Export).and_return({})
 
-      expect(subject.export).to eq(add_on_products)
+      expect(client.export).to eq(add_on_products)
     end
 
     it "returns empty hash if all types are empty" do
       expect(Yast::AddOnProduct).to receive(:Export).and_return({})
       expect(Yast::AddOnOthers).to receive(:Export).and_return({})
 
-      expect(subject.export).to eq({})
+      expect(client.export).to eq({})
     end
   end
 
@@ -355,7 +357,7 @@ describe Yast::AddOnAutoClient do
             # stop retrying and the error is finally displayed
             allow(Yast::Report).to receive(:Error)
 
-            subject.write
+            client.write
           end
         end
 
@@ -369,7 +371,7 @@ describe Yast::AddOnAutoClient do
           it "reports the error" do
             expect(Yast::Report).to receive(:Error)
 
-            subject.write
+            client.write
           end
         end
       end
@@ -377,13 +379,13 @@ describe Yast::AddOnAutoClient do
       it "stores repos according to information given" do
         expect(Yast::Pkg).to receive(:SourceEditSet).with(repos_to_store)
 
-        subject.write
+        client.write
       end
 
       it "releases the media accessors" do
         expect(Yast::Pkg).to receive(:SourceReleaseAll)
 
-        subject.write
+        client.write
       end
     end
   end
@@ -395,7 +397,7 @@ describe Yast::AddOnAutoClient do
       end
 
       it "returns false" do
-        expect(subject.read).to be_falsey
+        expect(client.read).to be_falsey
       end
     end
 
@@ -406,9 +408,9 @@ describe Yast::AddOnAutoClient do
       end
 
       it "reads add-ons configuration from the current system" do
-        expect(subject).to receive(:ReadFromSystem)
+        expect(client).to receive(:ReadFromSystem)
 
-        subject.read
+        client.read
       end
     end
   end

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -16,7 +16,7 @@ describe Yast::AddOnAutoClient do
       it "sets 'add_on_products' to empty array" do
         expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => [])
 
-        subject.import(something: nil)
+        subject.import(nil)
       end
     end
 

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -12,11 +12,15 @@ describe Yast::AddOnAutoClient do
         "add_on_others"   => add_on_others }
     end
 
-    context "when 'add_on_products' param is NOT given" do
-      it "sets 'add_on_products' to empty array" do
-        expect(Yast::AddOnProduct).to receive(:Import).with("add_on_products" => [])
+    context "when no data is given" do
+      it "does not try to import add-on products" do
+        expect(Yast::AddOnProduct).to_not receive(:Import)
 
         subject.import(nil)
+      end
+
+      it "returns true" do
+        expect(subject.import(nil)).to eq(true)
       end
     end
 


### PR DESCRIPTION
## Problem

The autoinstallation client crash when there is nothing to import. E.g., when the profile contains an empty `<add-on />` section

```ruby
NoMethodError:
  undefined method `fetch' for nil:NilClass
```

* https://trello.com/c/CDV7zhjG
* https://bugzilla.suse.com/show_bug.cgi?id=1189154

## Solution

Do not try to _fetch_ add-on products from `nil`. I.e., does nothing when #import receives `nil`


## Tests

* Fixed and updated unit testing

## Notes for reviewers

Better to review commit per commit, since there are two _noisy_ commits.