### PR TITLE
add_on: Check for -pkg UI Plug-In and Prompt to Install it if Needed

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 15 13:56:13 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- When the user clicks on "Run Software Manager", check for the
+  "pkg" UI extension and prompt user to install it if not present
+  (jsc#SLE-20346, jsc#SLE-20462)
+- 4.4.3
+
+-------------------------------------------------------------------
 Tue Aug 31 11:15:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Auto client does not crash when trying to import from an

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only
@@ -35,8 +35,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-packager >= 4.2.11
 
 Requires:       autoyast2-installation
-# ProductProfile
-Requires:       yast2 >= 3.0.1
+# UIExtensionChecker
+Requires:       yast2 >= 4.4.18
 Requires:       yast2-country
 Requires:       yast2-installation
 # Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -29,7 +29,8 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  update-desktop-files
-BuildRequires:  yast2 >= 3.0.1
+# UIExtensionChecker
+BuildRequires:  yast2 >= 4.4.18
 BuildRequires:  yast2-devtools >= 3.1.10
 # Y2packager::Resolvables
 BuildRequires:  yast2-packager >= 4.2.11

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -30,14 +30,14 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  update-desktop-files
 # UIExtensionChecker
-BuildRequires:  yast2 >= 4.4.18
+BuildRequires:  yast2 >= 4.4.19
 BuildRequires:  yast2-devtools >= 3.1.10
 # Y2packager::Resolvables
 BuildRequires:  yast2-packager >= 4.2.11
 
 Requires:       autoyast2-installation
 # UIExtensionChecker
-Requires:       yast2 >= 4.4.18
+Requires:       yast2 >= 4.4.19
 Requires:       yast2-country
 Requires:       yast2-installation
 # Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -15,6 +15,7 @@
 
 require "y2packager/medium_type"
 require "y2packager/resolvable"
+require "ui/ui_extension_checker"
 
 module Yast
   module AddOnAddOnWorkflowInclude
@@ -1788,11 +1789,15 @@ module Yast
 
           # Calling packager directly
         when :packager
-          Builtins.y2milestone("Calling packager...")
-          RunPackageSelector()
+          ui_extension_checker = UIExtensionChecker.new("pkg")
 
-          CreateAddOnsOverviewDialog()
-          RedrawAddOnsOverviewTable()
+          if ui_extension_checker.ok?
+            Builtins.y2milestone("Calling packager...")
+            RunPackageSelector()
+
+            CreateAddOnsOverviewDialog()
+            RedrawAddOnsOverviewTable()
+          end
 
           # Everything else
         else


### PR DESCRIPTION
## Trello

https://trello.com/c/gT8nMq7O/2635-3-featureshouldhave-handle-more-gracefully-when-libyui-libraries-are-missing


## Jira

- https://jira.suse.com/browse/SLE-20346
- https://jira.suse.com/browse/SLE-20462


## Related PRs

- Main PR: https://github.com/yast/yast-yast2/pull/1194
- https://github.com/yast/yast-packager/pull/578
- https://github.com/yast/yast-online-update/pull/36


## Short Description

If the "pkg" UI extension plug-in is not available (usually because it's not installed), offer to install it.

In this module this is only done when the user clicks on the "Run Software Manager" button; everything else can easily be done without that "pkg" UI extension.

For more information, see https://github.com/yast/yast-packager/pull/578

## Screenshots

![need-pkg-installed-qt](https://user-images.githubusercontent.com/11538225/133434569-45974db6-a6fa-4e03-bd29-f11097164730.png)

![need-pkg-installed-ncurses](https://user-images.githubusercontent.com/11538225/133434575-430ca38f-84e9-43c0-9e3d-426cda0bbf62.png)

