### PR TITLE
Properly set the custom repository name (#1191491)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 26 13:14:28 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly set the custom repository name (#1191491)
+- 4.4.4
+
+-------------------------------------------------------------------
 Wed Sep 15 13:56:13 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
 
 - When the user clicks on "Run Software Manager", check for the

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1191491
- Related to https://github.com/yast/yast-packager/pull/594
- The `add-on` module works a bit differently than the `repositories` module, if the repository name is not set it uses the product name in the repository
- This restores the original behavior after applying https://github.com/yast/yast-packager/pull/593