### PR TITLE
Drop support for subscription-tools (bsc#1193339)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  2 17:06:27 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Drop support for subscription-tools, that package is not present
+  in SLE15 anymore (bsc#1193339)
+- 4.4.5
+
+-------------------------------------------------------------------
 Fri Nov 26 13:14:28 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly set the custom repository name (bsc#1191491)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -707,19 +707,19 @@ module Yast
 
     def RunWizard
       aliases = {
-        "media"            => -> { MediaSelect() },
-        "install_product"  => -> { InstallProduct() }
+        "media"           => -> { MediaSelect() },
+        "install_product" => -> { InstallProduct() }
       }
 
       sequence = {
-        "ws_start"         => "media",
-        "media"            => {
+        "ws_start"        => "media",
+        "media"           => {
           abort:  :abort,
           next:   "install_product",
           finish: "install_product",
           skip:   :skip
         },
-        "install_product"  => {
+        "install_product" => {
           abort:  :abort,
           next:   :next,
           finish: :next

--- a/src/include/add-on/add-on-workflow.rb
+++ b/src/include/add-on/add-on-workflow.rb
@@ -41,7 +41,6 @@ module Yast
       Yast.import "SourceDialogs"
       Yast.import "SourceManager"
       Yast.import "PackageSystem"
-      Yast.import "ProductProfile"
       Yast.import "Stage"
       Yast.import "Wizard"
       Yast.import "Confirm"
@@ -706,30 +705,19 @@ module Yast
       ret
     end
 
-    # Check new product compliance; may abort the installation
-    def CheckCompliance
-      compliant = @added_repos.all? { |src_id| ProductProfile.CheckCompliance(src_id) }
-      compliant ? :next : :abort
-    end
-
     def RunWizard
       aliases = {
         "media"            => -> { MediaSelect() },
-        "install_product"  => -> { InstallProduct() },
-        "check_compliance" => -> { CheckCompliance() }
+        "install_product"  => -> { InstallProduct() }
       }
 
       sequence = {
         "ws_start"         => "media",
         "media"            => {
           abort:  :abort,
-          next:   "check_compliance",
-          finish: "check_compliance",
+          next:   "install_product",
+          finish: "install_product",
           skip:   :skip
-        },
-        "check_compliance" => {
-          abort: :abort,
-          next:  "install_product"
         },
         "install_product"  => {
           abort:  :abort,


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1193339
- The `subscription-tools` package is not present in SLE15 anymore
- 4.4.5