### PR TITLE
[SLE-15-SP1] Restores unexpanded repository URL

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 20 10:40:26 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Restore the repo unexpanded URL to get it properly saved in
+  the /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+- 4.1.16
+
+-------------------------------------------------------------------
 Wed Oct 13 09:20:18 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Auto client does not crash when trying to import from an

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.1.15
+Version:        4.1.16
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -211,6 +211,10 @@ module Yast
 
           return :continue
         end
+      ensure
+        # Restore the unexpanded URL to have the original URL
+        # in the saved /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+        Pkg.SourceChangeUrl(source_id, media_url)
       end
     end
 

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -209,12 +209,12 @@ module Yast
           adjust_source_attributes(add_on, source_id)
           install_product(product)
 
+          # Restore the unexpanded URL to have the original URL
+          # in the saved /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+          Pkg.SourceChangeUrl(source_id, media_url)
+
           return :continue
         end
-      ensure
-        # Restore the unexpanded URL to have the original URL
-        # in the saved /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
-        Pkg.SourceChangeUrl(source_id, media_url)
       end
     end
 


### PR DESCRIPTION
## Problem

Four years ago, while [refactoring the add-on auto client](https://github.com/yast/yast-add-on/pull/54), a line of code [for restoring the unexpanded repository URL](https://github.com/yast/yast-add-on/pull/28#issuecomment-291116098) was drop.

The reason behind removing that line was that, apparently, [it did nothing where it was](https://github.com/yast/yast-add-on/pull/54#pullrequestreview-130681351). However, recently we got a quite detailed [bug report](https://bugzilla.suse.com/show_bug.cgi?id=1194851) about AutoYaST replacing $releasever in add-on repos with the version number.

## Solution

After doing a bunch of manual testing, the line has been placed after creating the repo and installing the products, because in where it was it actually does not work.

## Tests

* Added unit test (in an attempt to avoid another regression to that regard)
* Added some missing unit tests
* Tested manually
  
  <details>
    <summary>Click to show/hide the AutoYaST profile used and an screenshot of the repo file in the installed system.</summary>

    ---
 
    ```xml
    <?xml version="1.0"?>
    <!DOCTYPE profile>
    <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
      <users config:type="list">
        <user>
          <encrypted config:type="boolean">false</encrypted>
          <user_password>linux</user_password>
          <username>root</username>
        </user>
      </users>
      <add-on>
        <add_on_others config:type="list">
          <listentry>
            <media_url>https://download.opensuse.org/distribution/leap/$releasever/repo/non-oss</media_url>
            <product>openSUSE</product>
            <alias>repo-non-oss</alias>
            <name>Testing AutoYaST - openSUSE Leap $releasever Non-OSS</name>
            <product_dir>/</product_dir>
          </listentry>
        </add_on_others>
      </add-on>
    </profile> 
    ```
  ![autoyast_honoring_releasever](https://user-images.githubusercontent.com/1691872/150325074-0a2737ea-c2e9-48d5-8f3c-69bbf03f4204.png)
</details>