### PR TITLE
[SLE-15-SP2] Restores unexpanded repository URL

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 20 10:40:26 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Restore the repo unexpanded URL to get it properly saved in
+  the /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+- 4.2.19
+
+-------------------------------------------------------------------
 Wed Oct 13 12:09:01 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Auto client does not crash when trying to import from an

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -218,6 +218,10 @@ module Yast
           adjust_source_attributes(add_on, source_id)
           install_product(product)
 
+          # Restore the unexpanded URL to have the original URL
+          # in the saved /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+          Pkg.SourceChangeUrl(source_id, media_url)
+
           return :continue
         end
       end


### PR DESCRIPTION
The same as #120 and #122, but for `SLE-15-SP2`. 

In short, it fixes restoring the unexpanded repository URL to have the original URL in the saved _/etc/zypp/repos.d_