### PR TITLE
Fix unit test

### DIFF
--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -342,7 +342,7 @@ describe Yast::AddOnAutoClient do
             end
 
             it "does not reports an error while retrying" do
-              expect(Yast::Report).to receive(:Error).exactly(1).time
+              expect(Yast::Report).to receive(:Error).exactly(1).times
 
               subject.write
             end


### PR DESCRIPTION
Using "times" receive count instead of its "time" alias, which was introduced in RSpec Mocks 3.9[1] (and SLE-15-SP1 is using 3.7).

No version bump/changelog update required since it is actually part of #120

[1] https://github.com/rspec/rspec-mocks/blob/main/Changelog.md#390--2019-10-07