### PR TITLE
[SLE-15-SP3] Restores unexpanded repository URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,8 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 350
+  Exclude:
+  - test/**/*
 
 # Offense count: 5
 # Configuration parameters: CountBlocks.

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 20 10:40:26 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Restore the repo unexpanded URL to get it properly saved in
+  the /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+- 4.3.10
+
+-------------------------------------------------------------------
 Tue Aug 31 11:15:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Auto client does not crash when trying to import from an

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -242,6 +242,10 @@ module Yast
           adjust_source_attributes(add_on, source_id)
           install_product(product)
 
+          # Restore the unexpanded URL to have the original URL
+          # in the saved /etc/zypp/repos.d file (bsc#972046, bsc#1194851).
+          Pkg.SourceChangeUrl(source_id, media_url)
+
           return :continue
         end
       end

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -313,12 +313,14 @@ describe Yast::AddOnAutoClient do
 
     context "when there are add-ons products" do
       let(:ask_on_error) { true }
+      let(:unexpanded_url) { "RELURL://product-$releasever.url" }
+      let(:expanded_url) { "RELURL://product-15.0.url" }
       let(:add_on_products) do
         [
           {
             "alias"        => "produc_alias",
             "ask_on_error" => ask_on_error,
-            "media_url"    => "RELURL://product.url",
+            "media_url"    => unexpanded_url,
             "priority"     => 20,
             "product_dir"  => "/"
           }
@@ -349,50 +351,20 @@ describe Yast::AddOnAutoClient do
       end
 
       before do
-        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
         allow(Yast::Pkg).to receive(:SourceEditSet)
         allow(Yast::Pkg).to receive(:SourceReleaseAll)
         allow(Yast::Pkg).to receive(:SourceCreate).and_return(1)
         allow(Yast::Pkg).to receive(:SourceEditGet).and_return(repos)
         allow(Yast::Pkg).to receive(:ExpandedUrl)
-        # To test indirectly the "preferred_name_for" method
+        # For testing #preferred_name_for" indirectly
         allow(Yast::Pkg).to receive(:RepositoryScan)
           .with(anything)
           .and_return([["Updated repo", "/"]])
-      end
 
-      context "and product creation fails" do
-        before do
-          allow(Yast::Pkg).to receive(:SourceCreate).and_return(-1)
-        end
+        allow(Yast::AddOnProduct).to receive(:add_on_products).and_return(add_on_products)
 
-        context "ask_on_error=true" do
-          let(:ask_on_error) { true }
-
-          it "ask to make it available" do
-            expect(Yast::Popup).to receive(:ContinueCancel).and_return false
-
-            # We are returning false on the ContinueCancel mock, so we decide to
-            # stop retrying and the error is finally displayed
-            allow(Yast::Report).to receive(:Error)
-
-            client.write
-          end
-        end
-
-        context "ask_on_error=false" do
-          let(:ask_on_error) { false }
-
-          it "does not ask to make it available" do
-            expect(Yast::Popup).to_not receive(:ContinueCancel)
-          end
-
-          it "reports the error" do
-            expect(Yast::Report).to receive(:Error)
-
-            client.write
-          end
-        end
+        # For testing regresion with $releasever (bsc#1194851)
+        allow(Yast::AddOnProduct).to receive(:SetRepoUrlAlias).and_return(expanded_url)
       end
 
       it "stores repos according to information given" do
@@ -405,6 +377,79 @@ describe Yast::AddOnAutoClient do
         expect(Yast::Pkg).to receive(:SourceReleaseAll)
 
         client.write
+      end
+
+      # For testing regresion with $releasever (bsc#1194851)
+      it "restores the unexpanded URL" do
+        expect(Yast::Pkg).to receive(:SourceChangeUrl).with(1, unexpanded_url)
+
+        client.write
+      end
+
+      context "and product creation fails" do
+        before do
+          allow(Yast::Report).to receive(:Error)
+          allow(Yast::Pkg).to receive(:SourceCreate).and_return(-1)
+          allow(Yast::Popup).to receive(:ContinueCancel).and_return(retry_on_error, false)
+        end
+
+        let(:retry_on_error) { true }
+
+        context "ask_on_error=true" do
+          it "ask the user to make it available" do
+            expect(Yast::Popup).to receive(:ContinueCancel)
+
+            client.write
+          end
+
+          context "and user wants to retry" do
+            let(:retry_on_error) { true }
+
+            it "tries it again" do
+              expect(Yast::Pkg).to receive(:SourceCreate).with(expanded_url, "/").twice
+
+              client.write
+            end
+
+            it "does not reports an error while retrying" do
+              expect(Yast::Report).to receive(:Error).exactly(1).times
+
+              client.write
+            end
+          end
+
+          context "and user decides not retrying" do
+            let(:retry_on_error) { false }
+
+            it "does not try it again" do
+              expect(Yast::Pkg).to receive(:SourceCreate).once
+
+              client.write
+            end
+
+            it "reports an error" do
+              expect(Yast::Report).to receive(:Error)
+
+              client.write
+            end
+          end
+        end
+
+        context "ask_on_error=false" do
+          let(:ask_on_error) { false }
+
+          it "does not ask to make it available" do
+            expect(Yast::Popup).to_not receive(:ContinueCancel)
+
+            client.write
+          end
+
+          it "reports the error" do
+            expect(Yast::Report).to receive(:Error)
+
+            client.write
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The same as #120/#122, and #121, but for `SLE-15-SP3`. 

In short, it fixes restoring the unexpanded repository URL to have the original URL in the saved _/etc/zypp/repos.d_