### PR TITLE
Enable RSpec verifying doubles (bsc#1194784)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 20 16:11:51 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Enable RSpec verifying doubles in unit tests to ensure that
+  the mocked methods really exist (bsc#1194784)
+- 4.4.6
+
+-------------------------------------------------------------------
 Thu Dec  2 17:06:27 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Drop support for subscription-tools, that package is not present

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -31,10 +31,13 @@ Yast.import "Progress"
 
 module Yast
   class AddOnAutoClient < ::Installation::AutoClient
+    def initialize
+      Yast.include self, "add-on/add-on-workflow.rb"
+      super
+    end
+
     def run
       textdomain "add-on"
-
-      Yast.include self, "add-on/add-on-workflow.rb"
 
       progress_orig = Progress.set(false)
       ret = super

--- a/test/add-on-workflow_test.rb
+++ b/test/add-on-workflow_test.rb
@@ -4,16 +4,19 @@ require_relative "./test_helper"
 
 require_relative "../src/include/add-on/add-on-workflow.rb"
 
-# just a dummy class for including the tested methods
-class AddOnAddOnWorkflowIncludeTest
-  include Yast::AddOnAddOnWorkflowInclude
-end
-
 Yast.import "AddOnProduct"
 Yast.import "SourceDialogs"
 
 describe Yast::AddOnAddOnWorkflowInclude do
-  subject { AddOnAddOnWorkflowIncludeTest.new }
+  subject do
+    # anonymous class for testing the include
+    klass = Class.new do
+      include Yast::AddOnAddOnWorkflowInclude
+      def TypeDialogOpts(_arg1, _arg2); end
+    end
+
+    klass.new
+  end
 
   describe ".media_type_selection" do
     context "Full medium installation with no add-ons yet" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,17 +7,15 @@ ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 ENV["LC_ALL"] = "en_US.UTF-8"
 
 require "yast"
+require "yast/rspec"
 
-# Stub a module to prevent its importation
-#
-# Useful for modules from different YaST packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set(name.to_sym, Class.new { def self.fake_method; end })
+# configure RSpec
+RSpec.configure do |config|
+  config.mock_with :rspec do |c|
+    # https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/partial-doubles
+    c.verify_partial_doubles = true
+  end
 end
-
-# Stub classes from other modules to speed up a build
-stub_module("AutoinstGeneral")
-stub_module("AutoinstSoftware")
 
 if ENV["COVERAGE"]
   require "simplecov"
@@ -45,3 +43,7 @@ if ENV["COVERAGE"]
     ]
   end
 end
+
+# mock missing YaST modules
+Yast::RSpec::Helpers.define_yast_module("AutoinstSoftware", methods: [:pmInit])
+Yast::RSpec::Helpers.define_yast_module("AutoinstGeneral")

--- a/test/y2add_on/clients/inst_add-on_test.rb
+++ b/test/y2add_on/clients/inst_add-on_test.rb
@@ -16,11 +16,11 @@ describe Yast::InstAddOnClient do
     before do
       allow(Yast::Linuxrc).to receive(:InstallInf).with("addon").and_return(addons)
       allow(subject).to receive(:NetworkSetupForAddons).and_return(:next)
-      allow(subject).to receive(:InstallProduct)
+      allow_any_instance_of(Yast::AddOnAddOnWorkflowInclude).to receive(:InstallProduct)
       allow(Yast::AddOnProduct).to receive(:skip_add_ons).and_return(skip_add_ons)
       allow(Yast::Installation).to receive(:add_on_selected).and_return(add_on_selected)
       allow(Yast::InstURL).to receive(:installInf2Url).and_return(inst_url)
-      allow(subject).to receive(:RunAddOnMainDialog).and_return(:next)
+      allow_any_instance_of(Yast::AddOnAddOnWorkflowInclude).to receive(:RunAddOnMainDialog).and_return(:next)
     end
 
     context "when add-on products selection should be skipped" do


### PR DESCRIPTION
- Enable RSpec verifying doubles in unit tests to ensure that the mocked methods really exist
