### PR TITLE
Support managing system in a chroot (bsc#1199840)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  7 16:19:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support managing system in a chroot (bsc#1199840)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/clients/add-on.rb
+++ b/src/clients/add-on.rb
@@ -20,6 +20,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "CommandLine"
       Yast.import "Directory"
+      Yast.import "Installation"
 
       Yast.include self, "add-on/add-on-workflow.rb"
       CommandLine.Run(
@@ -67,7 +68,7 @@ module Yast
       end
 
       # initialize target to import all trusted keys (#165849)
-      Pkg.TargetInitialize("/")
+      Pkg.TargetInitialize(Installation.destdir)
       Pkg.TargetLoad
 
       PackageCallbacks.InitPackageCallbacks

--- a/src/clients/vendor.rb
+++ b/src/clients/vendor.rb
@@ -95,7 +95,7 @@ module Yast
       if @update_dir != ""
         @cdpath = Ops.add(@cdpath, @update_dir)
       else
-        Pkg.TargetInit("/", false)
+        Pkg.TargetInit(Installation.destdir, false)
 
         base = Y2Packager::Resolvable.find(kind:     :product,
                                            status:   :installed,


### PR DESCRIPTION
## Problem

- When running the `add-on` module in the management container it does not display the installed add-ons properly.
- The problem is in the libzypp initialization


## Fix

- The fix is similar to https://github.com/yast/yast-packager/pull/621, do not hardcode the target path
- The `grep` command found a similar problem in the `vendor` client, though I could not test the fix, I do not have any testing vendor CD.

## Testing

- Tested manually

## Screenshots

Without the patch the module loads the add-ons from the container itself, it obviously does not contain any addons:

![add_on_container_broken](https://user-images.githubusercontent.com/907998/172434966-c5ad1760-5d04-476d-a8bf-a2e23339c98c.png)


With the patch the libzypp is properly initialized in the target and the installed add-ons are properly displayed:

![add_on_container_fixed](https://user-images.githubusercontent.com/907998/172435209-1a6724ef-97da-4838-91b2-6e13e0cf7d88.png)

