### PR TITLE
support 'repo' scheme for add-ons (jsc#SLE-22578, jsc#SLE-24584)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 25 08:37:56 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- support 'repo' scheme for add-ons (jsc#SLE-22578, jsc#SLE-24584)
+- 4.5.2
+
+-------------------------------------------------------------------
 Tue Jun  7 16:19:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Support managing system in a chroot (bsc#1199840)

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "installation/auto_client"
+require "uri"
 
 Yast.import "AddOnProduct"
 Yast.import "AddOnOthers"
@@ -262,7 +263,7 @@ module Yast
     def media_url_for(add_on)
       media_url = add_on.fetch("media_url", "")
 
-      if media_url.downcase.start_with?("relurl://")
+      if ["relurl", "repo"].include?(URI(media_url).scheme)
         media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.GetBaseProductURL, media_url)
 
         log.info("relurl changed to #{media_url}")


### PR DESCRIPTION
## Task

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

Support new `repo` URI scheme that works relative to the installation medium.

## See also

- https://github.com/yast/yast-packager/pull/624