### PR TITLE
Ignore extra white space in URL (bsc#1205928)

### DIFF
--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Dec  5 17:37:00 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
-- Fixed failure with CDATA URL containing white space in AutoYaST
-  profile (bsc#1205928)
+- Fixed failure with the "media_url" element in AutoYaST profile
+  containing CDATA block with spaces (bsc#1205928)
 - 4.4.8
 
 -------------------------------------------------------------------

--- a/package/yast2-add-on.changes
+++ b/package/yast2-add-on.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  5 17:37:00 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed failure with CDATA URL containing white space in AutoYaST
+  profile (bsc#1205928)
+- 4.4.8
+
+-------------------------------------------------------------------
 Thu Jan 20 16:40:26 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Restore the repo unexpanded URL to get it properly saved in

--- a/package/yast2-add-on.spec
+++ b/package/yast2-add-on.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Summary:        YaST2 - Add-On media installation code
 License:        GPL-2.0-only

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -206,7 +206,7 @@ module Yast
   private
 
     # Get URL for the addon
-    # @param [Hash] Addon data
+    # @param add_on [Hash] the add on data
     # @return [String] Addon URL or empty string if not set
     def addon_url(add_on)
       add_on.fetch("media_url", "").strip

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -55,7 +55,7 @@ module Yast
       add_ons += data.fetch("add_on_others", [])
 
       valid_add_ons = add_ons.reject.with_index(1) do |add_on, index|
-        next false unless add_on.fetch("media_url", "").empty?
+        next false unless addon_url(add_on).empty?
 
         log.error("Missing <media_url> value in the #{index}. add-on definition")
 
@@ -91,7 +91,7 @@ module Yast
 
         add_on_summary = []
         # TRANSLATORS: %s is an add-on URL
-        add_on_summary << _("URL: %s") % CGI.escapeHTML(add_on["media_url"])
+        add_on_summary << _("URL: %s") % CGI.escapeHTML(addon_url(add_on))
 
         if [nil, "", "/"].none?(product_dir)
           # TRANSLATORS: %s is a product path
@@ -205,6 +205,13 @@ module Yast
 
   private
 
+    # Get URL for the addon
+    # @param [Hash] Addon data
+    # @return [String] Addon URL or empty string if not set
+    def addon_url(add_on)
+      add_on.fetch("media_url", "").strip
+    end
+
     # Create repo and install product (if given)
     #
     # @param [Hash] add_on
@@ -260,7 +267,7 @@ module Yast
     #
     # @return [String] absolute media url or empty string
     def media_url_for(add_on)
-      media_url = add_on.fetch("media_url", "")
+      media_url = addon_url(add_on)
 
       if media_url.downcase.start_with?("relurl://")
         media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.GetBaseProductURL, media_url)
@@ -368,7 +375,7 @@ module Yast
       # name in control file, bnc#433981
       return add_on_name unless add_on_name.to_s.empty?
 
-      media_url = add_on.fetch("media_url", "")
+      media_url = addon_url(add_on)
       product_dir = add_on.fetch("product_dir", "/")
       expanded_url = Pkg.ExpandedUrl(media_url)
       repos_at_url = Pkg.RepositoryScan(expanded_url) || []

--- a/src/lib/add-on/clients/add-on_auto.rb
+++ b/src/lib/add-on/clients/add-on_auto.rb
@@ -55,7 +55,7 @@ module Yast
       add_ons += data.fetch("add_on_others", [])
 
       valid_add_ons = add_ons.reject.with_index(1) do |add_on, index|
-        next false unless addon_url(add_on).empty?
+        next false unless stripped_media_url(add_on).empty?
 
         log.error("Missing <media_url> value in the #{index}. add-on definition")
 
@@ -91,7 +91,7 @@ module Yast
 
         add_on_summary = []
         # TRANSLATORS: %s is an add-on URL
-        add_on_summary << _("URL: %s") % CGI.escapeHTML(addon_url(add_on))
+        add_on_summary << _("URL: %s") % CGI.escapeHTML(stripped_media_url(add_on))
 
         if [nil, "", "/"].none?(product_dir)
           # TRANSLATORS: %s is a product path
@@ -164,7 +164,7 @@ module Yast
     def write
       AddOnProduct.add_on_products.each do |add_on|
         product = add_on.fetch("product", "")
-        media_url = media_url_for(add_on)
+        media_url = absolute_media_url(add_on)
         action = create_source(add_on, product, media_url)
 
         case action
@@ -208,7 +208,7 @@ module Yast
     # Get URL for the addon
     # @param add_on [Hash] the add on data
     # @return [String] Addon URL or empty string if not set
-    def addon_url(add_on)
+    def stripped_media_url(add_on)
       add_on.fetch("media_url", "").strip
     end
 
@@ -266,8 +266,8 @@ module Yast
     # @param [Hash] add_on
     #
     # @return [String] absolute media url or empty string
-    def media_url_for(add_on)
-      media_url = addon_url(add_on)
+    def absolute_media_url(add_on)
+      media_url = stripped_media_url(add_on)
 
       if media_url.downcase.start_with?("relurl://")
         media_url = AddOnProduct.GetAbsoluteURL(AddOnProduct.GetBaseProductURL, media_url)
@@ -375,7 +375,7 @@ module Yast
       # name in control file, bnc#433981
       return add_on_name unless add_on_name.to_s.empty?
 
-      media_url = addon_url(add_on)
+      media_url = stripped_media_url(add_on)
       product_dir = add_on.fetch("product_dir", "/")
       expanded_url = Pkg.ExpandedUrl(media_url)
       repos_at_url = Pkg.RepositoryScan(expanded_url) || []

--- a/test/y2add_on/clients/add-on_auto_test.rb
+++ b/test/y2add_on/clients/add-on_auto_test.rb
@@ -386,6 +386,18 @@ describe Yast::AddOnAutoClient do
         client.write
       end
 
+      context "URL contains spaces" do
+        # simulate CDATA with spaces:
+        # <media_url><![CDATA[  relurl://  ]]></media_url>
+        let(:unexpanded_url) { "  RELURL://product-$releasever.url  " }
+
+        # test regression with CDATA (bsc#1205928)
+        it "strips the spaces from URL" do
+          expect(Yast::Pkg).to receive(:ExpandedUrl).with(unexpanded_url.strip)
+          client.write
+        end
+      end
+
       context "and product creation fails" do
         before do
           allow(Yast::Report).to receive(:Error)


### PR DESCRIPTION
## Problem

- Fixes a problem with `<media_url><![CDATA[ relurl:// ]]></media_url>` in the AutoYaST profile (note the spaces around the URL). That is read as " relurl:// " string which is an invalid URL.
- See https://bugzilla.suse.com/show_bug.cgi?id=1205928
- Related to https://github.com/yast/yast-yast2/pull/1243 which keeps the spaces

## Solution

- Strip the white space from the URL

## Testing

- Added a new unit test
- Tested manually, installation works fine with `<![CDATA[ relurl:// ]]>`
